### PR TITLE
fix: trim published package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
 	"bin": {
 		"nanotune": "./dist/cli.js"
 	},
+	"files": [
+		"dist",
+		"!dist/**/*.spec.*",
+		"README.md",
+		"LICENSE.md",
+		"CHANGELOG.md"
+	],
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsx src/cli.tsx",

--- a/src/lib/package.spec.ts
+++ b/src/lib/package.spec.ts
@@ -1,0 +1,16 @@
+import {readFileSync} from 'node:fs';
+import test from 'ava';
+
+const packageJson = JSON.parse(
+	readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+) as {files: string[]};
+
+test('publishes runtime files without compiled specs', t => {
+	t.deepEqual(packageJson.files, [
+		'dist',
+		'!dist/**/*.spec.*',
+		'README.md',
+		'LICENSE.md',
+		'CHANGELOG.md',
+	]);
+});


### PR DESCRIPTION
## Description

Limit the npm package to the compiled runtime and user-facing package docs. Compiled `*.spec.*` artifacts are explicitly excluded because they live under `dist/` after the TypeScript build. A focused AVA regression pins the publish allowlist.

Before: 192 files, 2,733,564 bytes compressed, 3,497,149 bytes unpacked.
After: 70 files, 62,989 bytes compressed, 249,467 bytes unpacked.

That is a 97.7% compressed-size reduction. The resulting tarball contains no `src/`, spec files, `tsconfig.json`, docs tree, or badges. Installing the actual tarball and running `nanotune --version` returns `1.6.0`.

Closes #75

Implemented with Codex agent assistance; I reviewed the package contract, before/after contents, test coverage, and final diff.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing checks pass (`pnpm test:lint`, `test:types`, `test:knip`, `test:audit`, 240 AVA tests, Semgrep)
- [x] New regression added for the publish allowlist

### Manual Testing

- [ ] Tested `nanotune init` (not affected)
- [ ] Tested `nanotune data` commands (not affected)
- [ ] Tested `nanotune train` (not affected)
- [ ] Tested `nanotune export` (not affected)
- [ ] Tested `nanotune benchmark` (not affected)
- [x] Built, packed, installed, and executed the generated tarball

## Checklist

- [x] Code follows project style guidelines (`pnpm test:lint`)
- [x] Self-review completed
- [x] Documentation unchanged because the public CLI/API is unchanged
- [x] No breaking changes