### PR TITLE
fix: surface the train/validation split and make it inspectable

### DIFF
--- a/docs/commands/data.md
+++ b/docs/commands/data.md
@@ -26,6 +26,12 @@ The interactive flow supports multi-turn conversations:
 
 Accumulated turns are shown above the input fields as you build the conversation.
 
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-e, --eval` | Add to the validation set (`valid.jsonl`) instead of training data |
+
 ## nanotune data import
 
 ```bash
@@ -49,6 +55,7 @@ Multi-turn examples in JSONL and JSON files are preserved with all their turns i
 | Flag | Description |
 |------|-------------|
 | `-y, --yes` | Skip the confirmation prompt |
+| `-e, --eval` | Import into the validation set (`valid.jsonl`) instead of training data |
 
 By default the importer previews your existing data and asks for confirmation. Pass `--yes` to import without prompting — this is also what lets `data import` run in a script or CI job, where there is no terminal to answer the prompt.
 
@@ -103,6 +110,15 @@ View and manage your training data with pagination, editing, and delete. Shows a
 | d | Delete the selected example |
 | q | Quit |
 
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-e, --eval` | View the validation set (`valid.jsonl`) instead of training data |
+
+The header also reports the other set's size, so a split is visible from either
+side.
+
 Editing reuses the same input flow as `data add`, but only covers the example's **first** user/assistant turn — any additional turns and the example's context message are preserved unchanged. Press **Tab** to switch between the input and output fields, **Enter** to submit a field, and **Esc** to cancel without saving.
 
 ## nanotune data validate
@@ -126,12 +142,17 @@ Validate your training data before training. Checks for:
 |------|-------------|
 | `--fix` | Remove exact-duplicate examples (identical messages, not just matching input text) |
 | `--rewrite-context` | Rewrite each example's context message to match the current config |
+| `-e, --eval` | Validate the validation set (`valid.jsonl`) instead of training data |
 
 `--fix` is intentionally stricter than the "duplicate user inputs" warning above: the warning flags examples that merely share the same input text (worth a human look, since the outputs or context could differ on purpose), while `--fix` only ever removes examples whose entire message list is identical — the only case where deleting one is provably safe. `--rewrite-context` only touches examples that already have a context/system message; it never inserts one where an example starts directly with a user message. Both flags report exactly how many examples they changed, and can be combined:
 
 ```bash
 nanotune data validate --fix --rewrite-context
 ```
+
+After a split, `data validate` reports on `train.jsonl` only. Pass `--eval` to
+check `valid.jsonl` too — the "recommend at least 50 examples" warning is not
+applied there, since a validation set is a slice of the training data.
 
 ## See Also
 

--- a/docs/commands/train.md
+++ b/docs/commands/train.md
@@ -22,6 +22,12 @@ nanotune train
 | `--lr <rate>` | Override learning rate |
 | `--resume` | Resume from last checkpoint |
 | `--dry-run` | Validate config without training |
+| `--seed <n>` | Integer seed for a reproducible train/validation split |
+
+`--seed` only affects the run that actually creates the split. Once `valid.jsonl`
+exists the split is left alone, so passing a seed to an already-split project
+does nothing and `train` says so — delete `valid.jsonl` first to re-split. A
+non-integer seed is rejected rather than silently coerced.
 
 ## Examples
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -78,7 +78,10 @@ dataCommand
 dataCommand
 	.command('export <file>')
 	.description('Export training data to file (JSONL, CSV, or JSON)')
-	.option('-y, --yes', 'Skip the overwrite confirmation prompt (for scripts and CI)')
+	.option(
+		'-y, --yes',
+		'Skip the overwrite confirmation prompt (for scripts and CI)',
+	)
 	.action(async (file: string, options: {yes?: boolean}) => {
 		const {DataExportCommand} = await import('./commands/data/export.js');
 		// Without a TTY there is no way to answer the overwrite prompt, so require --yes.

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -109,15 +109,23 @@ dataCommand
 		'--rewrite-context',
 		"Rewrite each example's context message to match the current config",
 	)
-	.action(async (options: {fix?: boolean; rewriteContext?: boolean}) => {
-		const {DataValidateCommand} = await import('./commands/data/validate.js');
-		render(
-			<DataValidateCommand
-				fix={options.fix}
-				rewriteContext={options.rewriteContext}
-			/>,
-		);
-	});
+	.option('-e, --eval', 'Validate the validation set instead of training data')
+	.action(
+		async (options: {
+			fix?: boolean;
+			rewriteContext?: boolean;
+			eval?: boolean;
+		}) => {
+			const {DataValidateCommand} = await import('./commands/data/validate.js');
+			render(
+				<DataValidateCommand
+					fix={options.fix}
+					rewriteContext={options.rewriteContext}
+					isEval={options.eval}
+				/>,
+			);
+		},
+	);
 
 // Train command
 program

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -47,16 +47,21 @@ const dataCommand = program.command('data').description('Manage training data');
 dataCommand
 	.command('add')
 	.description('Interactively add training examples')
-	.action(async () => {
+	.option('-e, --eval', 'Add to the validation set instead of training data')
+	.action(async (options: {eval?: boolean}) => {
 		const {DataAddCommand} = await import('./commands/data/add.js');
-		renderInteractive('data add', <DataAddCommand />);
+		renderInteractive('data add', <DataAddCommand isEval={options.eval} />);
 	});
 
 dataCommand
 	.command('import <file>')
 	.description('Import training data from file (JSONL, CSV, or JSON)')
 	.option('-y, --yes', 'Skip the confirmation prompt (for scripts and CI)')
-	.action(async (file: string, options: {yes?: boolean}) => {
+	.option(
+		'-e, --eval',
+		'Import into the validation set instead of training data',
+	)
+	.action(async (file: string, options: {yes?: boolean; eval?: boolean}) => {
 		const {DataImportCommand} = await import('./commands/data/import.js');
 		// Without a TTY there is no way to answer the prompt, so require --yes.
 		if (!options.yes && !supportsRawMode()) {
@@ -65,7 +70,9 @@ dataCommand
 			process.exitCode = 1;
 			return;
 		}
-		render(<DataImportCommand file={file} yes={options.yes} />);
+		render(
+			<DataImportCommand file={file} yes={options.yes} isEval={options.eval} />,
+		);
 	});
 
 dataCommand
@@ -88,9 +95,10 @@ dataCommand
 	.command('list')
 	.alias('ls')
 	.description('View training data')
-	.action(async () => {
+	.option('-e, --eval', 'View the validation set instead of training data')
+	.action(async (options: {eval?: boolean}) => {
 		const {DataListCommand} = await import('./commands/data/list.js');
-		renderInteractive('data list', <DataListCommand />);
+		renderInteractive('data list', <DataListCommand isEval={options.eval} />);
 	});
 
 dataCommand
@@ -119,6 +127,7 @@ program
 	.option('--lr <rate>', 'Learning rate')
 	.option('--resume', 'Resume from last checkpoint')
 	.option('--dry-run', 'Validate config without training')
+	.option('--seed <n>', 'Seed for a reproducible train/validation split')
 	.action(async options => {
 		const {TrainCommand} = await import('./commands/train.js');
 		render(<TrainCommand options={options} />);

--- a/src/commands/data/add.tsx
+++ b/src/commands/data/add.tsx
@@ -12,7 +12,11 @@ import type {ChatMessage} from '../../types/index.js';
 
 type Field = 'input' | 'output' | 'confirm';
 
-export function DataAddCommand() {
+interface Props {
+	isEval?: boolean;
+}
+
+export function DataAddCommand({isEval = false}: Props) {
 	const {exit} = useApp();
 	const [field, setField] = useState<Field>('input');
 	const [input, setInput] = useState('');
@@ -20,7 +24,7 @@ export function DataAddCommand() {
 	const [turns, setTurns] = useState<Array<{user: string; assistant: string}>>(
 		[],
 	);
-	const [count, setCount] = useState(() => countExamples());
+	const [count, setCount] = useState(() => countExamples(isEval));
 	const [savedMessage, setSavedMessage] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [hasConfig] = useState(() => configExists());
@@ -34,7 +38,7 @@ export function DataAddCommand() {
 				messages.push({role: 'user', content: turn.user});
 				messages.push({role: 'assistant', content: turn.assistant});
 			}
-			appendTrainingExample({messages});
+			appendTrainingExample({messages}, isEval);
 
 			const turnCount = turns.length;
 			setCount(c => c + 1);
@@ -104,7 +108,7 @@ export function DataAddCommand() {
 	if (!hasConfig) {
 		return (
 			<Box flexDirection="column" padding={1}>
-				<Header title="Add Training Data" />
+				<Header title={isEval ? 'Add Validation Data' : 'Add Training Data'} />
 				<StatusMessage variant="error">
 					Not a Nanotune project. Run `nanotune init` first.
 				</StatusMessage>
@@ -114,7 +118,7 @@ export function DataAddCommand() {
 
 	return (
 		<Box flexDirection="column" padding={1}>
-			<Header title="Add Training Data" />
+			<Header title={isEval ? 'Add Validation Data' : 'Add Training Data'} />
 
 			<Box marginBottom={1}>
 				<Text>Examples: </Text>

--- a/src/commands/data/import.tsx
+++ b/src/commands/data/import.tsx
@@ -24,9 +24,10 @@ interface Props {
 	file: string;
 	/** Skip the y/n confirmation — needed to run under CI or in a pipeline. */
 	yes?: boolean;
+	isEval?: boolean;
 }
 
-export function DataImportCommand({file, yes}: Props) {
+export function DataImportCommand({file, yes, isEval = false}: Props) {
 	const {exit} = useApp();
 	const [status, setStatus] = useState<
 		'preview' | 'importing' | 'done' | 'error'
@@ -38,7 +39,7 @@ export function DataImportCommand({file, yes}: Props) {
 	useEffect(() => {
 		// Load preview
 		try {
-			const existingData = loadTrainingData();
+			const existingData = loadTrainingData(isEval);
 			const previewItems = existingData.slice(0, 3).map(ex => {
 				const user = ex.messages.find(m => m.role === 'user');
 				const assistant = ex.messages.find(m => m.role === 'assistant');
@@ -50,7 +51,7 @@ export function DataImportCommand({file, yes}: Props) {
 		} catch {
 			// Ignore preview errors
 		}
-	}, []);
+	}, [isEval]);
 
 	const doImport = useCallback(() => {
 		try {
@@ -62,7 +63,11 @@ export function DataImportCommand({file, yes}: Props) {
 
 			const config = loadConfig();
 			const filePath = resolve(process.cwd(), file);
-			const importResult = importData(filePath, resolveContextMessage(config));
+			const importResult = importData(
+				filePath,
+				resolveContextMessage(config),
+				isEval,
+			);
 
 			setResult(importResult);
 			setStatus('done');
@@ -70,7 +75,7 @@ export function DataImportCommand({file, yes}: Props) {
 			setError(err instanceof Error ? err.message : 'Import failed');
 			setStatus('error');
 		}
-	}, [file]);
+	}, [file, isEval]);
 
 	// `--yes` skips straight past the confirmation prompt.
 	useEffect(() => {
@@ -97,7 +102,9 @@ export function DataImportCommand({file, yes}: Props) {
 	if (!configExists()) {
 		return (
 			<Box flexDirection="column" padding={1}>
-				<Header title="Import Training Data" />
+				<Header
+					title={isEval ? 'Import Validation Data' : 'Import Training Data'}
+				/>
 				<StatusMessage variant="error">
 					Not a Nanotune project. Run `nanotune init` first.
 				</StatusMessage>
@@ -107,7 +114,9 @@ export function DataImportCommand({file, yes}: Props) {
 
 	return (
 		<Box flexDirection="column" padding={1}>
-			<Header title="Import Training Data" />
+			<Header
+				title={isEval ? 'Import Validation Data' : 'Import Training Data'}
+			/>
 
 			{status === 'preview' && (
 				<Box flexDirection="column">
@@ -118,7 +127,9 @@ export function DataImportCommand({file, yes}: Props) {
 
 					{preview.length > 0 && (
 						<Box flexDirection="column" marginBottom={1}>
-							<Text bold>Preview of existing data:</Text>
+							<Text bold>
+								Preview of existing {isEval ? 'validation' : 'training'} data:
+							</Text>
 							{preview.map((p, i) => (
 								<Text key={i} dimColor>
 									{p}

--- a/src/commands/data/list.tsx
+++ b/src/commands/data/list.tsx
@@ -4,6 +4,7 @@ import {useState} from 'react';
 import {DataTable, Header, useKeyInput} from '../../components/index.js';
 import {configExists} from '../../lib/config.js';
 import {
+	countExamples,
 	countTurns,
 	deleteExample,
 	loadTrainingData,
@@ -16,12 +17,17 @@ type EditField = 'input' | 'output';
 
 const PAGE_SIZE = 10;
 
-export function DataListCommand() {
+interface Props {
+	isEval?: boolean;
+}
+
+export function DataListCommand({isEval = false}: Props) {
 	const {exit} = useApp();
 	const [page, setPage] = useState(0);
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-	const [data, setData] = useState(() => loadTrainingData());
+	const [data, setData] = useState(() => loadTrainingData(isEval));
+	const [otherCount] = useState(() => countExamples(!isEval));
 	const [message, setMessage] = useState<{
 		type: 'success' | 'error';
 		text: string;
@@ -135,8 +141,8 @@ export function DataListCommand() {
 			const globalIndex = startIndex + selectedIndex;
 			if (globalIndex < data.length) {
 				try {
-					deleteExample(globalIndex);
-					setData(loadTrainingData());
+					deleteExample(globalIndex, isEval);
+					setData(loadTrainingData(isEval));
 					setExpandedIndex(null);
 					setMessage({type: 'success', text: 'Example deleted'});
 					setTimeout(() => setMessage(null), 2000);
@@ -173,7 +179,7 @@ export function DataListCommand() {
 	if (!hasConfig) {
 		return (
 			<Box flexDirection="column" padding={1}>
-				<Header title="Training Data" />
+				<Header title={isEval ? 'Validation Data' : 'Training Data'} />
 				<StatusMessage variant="error">
 					Not a Nanotune project. Run `nanotune init` first.
 				</StatusMessage>
@@ -259,8 +265,12 @@ export function DataListCommand() {
 	return (
 		<Box flexDirection="column" padding={1}>
 			<Header
-				title="Training Data"
-				subtitle={`${data.length} examples | Page ${page + 1}/${totalPages || 1}`}
+				title={isEval ? 'Validation Data' : 'Training Data'}
+				subtitle={`${data.length} examples${
+					otherCount > 0
+						? ` (+${otherCount} ${isEval ? 'training' : 'validation'})`
+						: ''
+				} | Page ${page + 1}/${totalPages || 1}`}
 			/>
 
 			{message && (
@@ -271,9 +281,13 @@ export function DataListCommand() {
 
 			{data.length === 0 ? (
 				<Box flexDirection="column">
-					<Text dimColor>No training data yet.</Text>
+					<Text dimColor>
+						No {isEval ? 'validation' : 'training'} data yet.
+					</Text>
 					<Text>
-						Run <Text color="cyan">nanotune data add</Text> to add examples.
+						Run{' '}
+						<Text color="cyan">nanotune data add{isEval ? ' --eval' : ''}</Text>{' '}
+						to add examples.
 					</Text>
 				</Box>
 			) : (

--- a/src/commands/data/list.tsx
+++ b/src/commands/data/list.tsx
@@ -49,7 +49,11 @@ export function DataListCommand({isEval = false}: Props) {
 		try {
 			const original = data[editIndex];
 			const updated: {messages: ChatMessage[]} = {
-				messages: mergeEditedTurn(original.messages, userInput, assistantOutput),
+				messages: mergeEditedTurn(
+					original.messages,
+					userInput,
+					assistantOutput,
+				),
 			};
 			updateTrainingExample(editIndex, updated);
 			setData(loadTrainingData());

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -13,8 +13,8 @@ import {
 	resolveContextMessage,
 } from '../../lib/config.js';
 import {
-	countExamples,
 	type ContextFixResult,
+	countExamples,
 	type DedupeResult,
 	dedupeExamples,
 	fixContextMessages,

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -24,9 +24,14 @@ import {
 interface Props {
 	fix?: boolean;
 	rewriteContext?: boolean;
+	isEval?: boolean;
 }
 
-export function DataValidateCommand({fix, rewriteContext}: Props) {
+export function DataValidateCommand({
+	fix,
+	rewriteContext,
+	isEval = false,
+}: Props) {
 	const {exit} = useApp();
 	const hasConfig = configExists();
 
@@ -36,24 +41,30 @@ export function DataValidateCommand({fix, rewriteContext}: Props) {
 		}
 	});
 
+	const setName = isEval ? 'Validation data' : 'Training data';
+	const title = isEval ? 'Validate Validation Data' : 'Validate Training Data';
+
 	let dedupeResult: DedupeResult | null = null;
 	let contextFixResult: ContextFixResult | null = null;
 	if (hasConfig) {
 		// Rewrite context first: examples that only become identical after
 		// context normalization must still be caught by dedupe in this pass.
 		if (rewriteContext) {
-			contextFixResult = fixContextMessages(resolveContextMessage(loadConfig()));
+			contextFixResult = fixContextMessages(
+				resolveContextMessage(loadConfig()),
+				isEval,
+			);
 		}
 		if (fix) {
-			dedupeResult = dedupeExamples();
+			dedupeResult = dedupeExamples(isEval);
 		}
 	}
 
 	// Re-validate after fixes are applied so the report reflects the data
 	// actually left on disk.
-	const count = hasConfig ? countExamples() : 0;
+	const count = hasConfig ? countExamples(isEval) : 0;
 	const result = hasConfig
-		? validateTrainingData(resolveContextMessage(loadConfig()))
+		? validateTrainingData(resolveContextMessage(loadConfig()), isEval)
 		: null;
 
 	// Report is fully rendered on first pass — without a keyboard there is
@@ -63,7 +74,7 @@ export function DataValidateCommand({fix, rewriteContext}: Props) {
 	if (!hasConfig || !result) {
 		return (
 			<Box flexDirection="column" padding={1}>
-				<Header title="Validate Training Data" />
+				<Header title={title} />
 				<StatusMessage variant="error">
 					Not a Nanotune project. Run `nanotune init` first.
 				</StatusMessage>
@@ -73,7 +84,7 @@ export function DataValidateCommand({fix, rewriteContext}: Props) {
 
 	return (
 		<Box flexDirection="column" padding={1}>
-			<Header title="Validate Training Data" />
+			<Header title={title} />
 
 			<Box marginBottom={1}>
 				<Text>Examples: </Text>
@@ -115,9 +126,9 @@ export function DataValidateCommand({fix, rewriteContext}: Props) {
 			)}
 
 			{result.valid ? (
-				<StatusMessage variant="success">Training data is valid!</StatusMessage>
+				<StatusMessage variant="success">{`${setName} is valid!`}</StatusMessage>
 			) : (
-				<StatusMessage variant="error">Training data has errors</StatusMessage>
+				<StatusMessage variant="error">{`${setName} has errors`}</StatusMessage>
 			)}
 
 			{result.errors.length > 0 && (

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -75,6 +75,7 @@ export function StatusCommand() {
 
 	// Training data info
 	const exampleCount = countExamples();
+	const validCount = countExamples(true);
 	const trainFile = join(dataDir, 'train.jsonl');
 	const trainModified = existsSync(trainFile)
 		? formatRelativeTime(statSync(trainFile).mtime)
@@ -147,7 +148,10 @@ export function StatusCommand() {
 				<Text> </Text>
 				<Text bold>Training Data:</Text>
 				<Text>
-					{'  '}Examples: <Text color="cyan">{exampleCount}</Text>
+					{'  '}Training Examples: <Text color="cyan">{exampleCount}</Text>
+				</Text>
+				<Text>
+					{'  '}Validation Examples: <Text color="cyan">{validCount}</Text>
 				</Text>
 				{trainModified && (
 					<Text dimColor>

--- a/src/commands/train.tsx
+++ b/src/commands/train.tsx
@@ -62,6 +62,7 @@ export function TrainCommand({options}: Props) {
 		validCount: number;
 		didSplit: boolean;
 	} | null>(null);
+	const [seedIgnored, setSeedIgnored] = useState(false);
 
 	useKeyInput((input, key) => {
 		if (key.escape && status !== 'training' && status !== 'downloading') {
@@ -76,6 +77,25 @@ export function TrainCommand({options}: Props) {
 
 	const run = useCallback(async () => {
 		try {
+			// Parse the seed before any work happens. Number.parseInt would turn
+			// a typo into NaN and mulberry32 would coerce that to 0, producing a
+			// confidently deterministic split under a seed the user never asked
+			// for; `--seed 3.7` would silently truncate the same way. Number()
+			// rejects both, but reads blank input as 0, so that is screened out
+			// first. Testing against undefined rather than truthiness keeps
+			// `--seed 0` a real seed.
+			let seed: number | undefined;
+			if (options.seed !== undefined) {
+				const raw = options.seed.trim();
+				const parsed = raw === '' ? Number.NaN : Number(raw);
+				if (!Number.isInteger(parsed)) {
+					setError(`Invalid --seed "${options.seed}": expected an integer.`);
+					setStatus('error');
+					return;
+				}
+				seed = parsed;
+			}
+
 			// Fail fast on unsupported hardware. Without this the run dies much
 			// later inside `pip install mlx-lm` with an opaque resolver error.
 			assertSupportedPlatform();
@@ -119,10 +139,6 @@ export function TrainCommand({options}: Props) {
 				return;
 			}
 
-			// Ensure we have a validation set (MLX requires it)
-			const seed = options.seed ? Number.parseInt(options.seed, 10) : undefined;
-			setSplit(ensureValidationSet(seed));
-
 			// Load config
 			const config = loadConfig();
 
@@ -134,10 +150,22 @@ export function TrainCommand({options}: Props) {
 				? Number.parseFloat(options.lr)
 				: config.training.learningRate;
 
-			// Dry run check
+			// Dry run check. This returns before the split so that a command
+			// documented as "validate config without training" leaves train.jsonl
+			// and valid.jsonl exactly as it found them.
 			if (options.dryRun) {
 				setStatus('done');
 				return;
+			}
+
+			// Ensure we have a validation set (MLX requires it).
+			const split = ensureValidationSet(seed);
+			setSplit(split);
+			// The split only happens when there is no validation set yet, so a
+			// seed handed to an already-split project changes nothing. Saying so
+			// beats letting the user believe they re-rolled the split.
+			if (seed !== undefined && !split.didSplit) {
+				setSeedIgnored(true);
 			}
 
 			// Download model if not cached
@@ -228,8 +256,10 @@ export function TrainCommand({options}: Props) {
 	}
 
 	const config = loadConfig();
-	const exampleCount = countExamples();
-	const validCount = countExamples(true);
+	// This component re-renders on every training update, so prefer the counts
+	// the split already returned over re-reading both files each time.
+	const exampleCount = split ? split.trainCount : countExamples();
+	const validCount = split ? split.validCount : countExamples(true);
 
 	return (
 		<Box flexDirection="column" padding={1}>
@@ -248,6 +278,12 @@ export function TrainCommand({options}: Props) {
 					<Text color="yellow">
 						Split {split.trainCount + split.validCount} examples into{' '}
 						{split.trainCount} train / {split.validCount} validation.
+					</Text>
+				)}
+				{seedIgnored && (
+					<Text color="yellow">
+						Existing validation set found - --seed ignored. Delete valid.jsonl
+						to re-split.
 					</Text>
 				)}
 				<Text>

--- a/src/commands/train.tsx
+++ b/src/commands/train.tsx
@@ -34,6 +34,7 @@ interface Props {
 		lr?: string;
 		resume?: boolean;
 		dryRun?: boolean;
+		seed?: string;
 	};
 }
 
@@ -56,6 +57,11 @@ export function TrainCommand({options}: Props) {
 	const [downloadPercent, setDownloadPercent] = useState<number | null>(null);
 	const [downloadDetail, setDownloadDetail] = useState<string | null>(null);
 	const [elapsed, setElapsed] = useState<string | null>(null);
+	const [split, setSplit] = useState<{
+		trainCount: number;
+		validCount: number;
+		didSplit: boolean;
+	} | null>(null);
 
 	useKeyInput((input, key) => {
 		if (key.escape && status !== 'training' && status !== 'downloading') {
@@ -114,7 +120,8 @@ export function TrainCommand({options}: Props) {
 			}
 
 			// Ensure we have a validation set (MLX requires it)
-			ensureValidationSet();
+			const seed = options.seed ? Number.parseInt(options.seed, 10) : undefined;
+			setSplit(ensureValidationSet(seed));
 
 			// Load config
 			const config = loadConfig();
@@ -197,7 +204,13 @@ export function TrainCommand({options}: Props) {
 			setError(err instanceof Error ? err.message : 'Training failed');
 			setStatus('error');
 		}
-	}, [options.iterations, options.lr, options.resume, options.dryRun]);
+	}, [
+		options.iterations,
+		options.lr,
+		options.resume,
+		options.dryRun,
+		options.seed,
+	]);
 
 	useEffect(() => {
 		run();
@@ -216,6 +229,7 @@ export function TrainCommand({options}: Props) {
 
 	const config = loadConfig();
 	const exampleCount = countExamples();
+	const validCount = countExamples(true);
 
 	return (
 		<Box flexDirection="column" padding={1}>
@@ -226,8 +240,16 @@ export function TrainCommand({options}: Props) {
 					Model: <Text color="cyan">{config.baseModel}</Text>
 				</Text>
 				<Text>
-					Examples: <Text color="cyan">{exampleCount}</Text>
+					Examples: <Text color="cyan">{exampleCount}</Text> train
+					{' | '}
+					<Text color="cyan">{validCount}</Text> validation
 				</Text>
+				{split?.didSplit && (
+					<Text color="yellow">
+						Split {split.trainCount + split.validCount} examples into{' '}
+						{split.trainCount} train / {split.validCount} validation.
+					</Text>
+				)}
 				<Text>
 					Iterations:{' '}
 					<Text color="cyan">

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -9,6 +9,7 @@ import {
   countTurns,
   dedupeExamples,
   deleteExample,
+  ensureValidationSet,
   exportData,
   exportToCSV,
   exportToJSON,
@@ -1207,3 +1208,142 @@ test.serial(
     t.is(result.trainCount, 1);
   },
 );
+
+// ── ensureValidationSet ───────────────────────────────────────────────
+
+test.serial("ensureValidationSet splits and reports it when no valid.jsonl exists", (t) => {
+  seedExamples(10);
+
+  const result = ensureValidationSet(1);
+
+  t.true(result.didSplit);
+  t.is(result.trainCount, 9);
+  t.is(result.validCount, 1);
+  t.is(countExamples(false), 9);
+  t.is(countExamples(true), 1);
+});
+
+test.serial("ensureValidationSet leaves an existing validation set alone", (t) => {
+  seedExamples(10);
+  ensureValidationSet(1);
+
+  const second = ensureValidationSet(1);
+
+  t.false(second.didSplit);
+  t.is(second.trainCount, 9);
+  t.is(second.validCount, 1);
+});
+
+test.serial("ensureValidationSet reports counts that account for every example", (t) => {
+  seedExamples(10);
+
+  const result = ensureValidationSet(1);
+
+  t.is(result.trainCount + result.validCount, 10);
+});
+
+test.serial("ensureValidationSet forwards its seed to the split", (t) => {
+  seedExamples(20);
+  ensureValidationSet(42);
+  const firstValid = loadTrainingData(true).map((ex) => ex.messages[1].content);
+
+  rmSync(DATA_DIR, { recursive: true, force: true });
+  mkdirSync(DATA_DIR, { recursive: true });
+  seedExamples(20);
+  ensureValidationSet(42);
+  const secondValid = loadTrainingData(true).map((ex) => ex.messages[1].content);
+
+  t.deepEqual(firstValid, secondValid);
+});
+
+test.serial("ensureValidationSet returns zero counts with no data at all", (t) => {
+  const result = ensureValidationSet(1);
+
+  t.false(result.didSplit);
+  t.is(result.trainCount, 0);
+  t.is(result.validCount, 0);
+});
+
+// ── isEval imports ────────────────────────────────────────────────────
+
+test.serial("importFromJSONL writes to valid.jsonl when isEval is true", (t) => {
+  const jsonlPath = join(TEST_DIR, "in.jsonl");
+  writeFileSync(
+    jsonlPath,
+    `${JSON.stringify({ input: "q", output: "a" })}\n`,
+  );
+
+  const result = importFromJSONL(jsonlPath, SYSTEM_CTX, true);
+
+  t.is(result.imported, 1);
+  t.is(countExamples(true), 1);
+  t.is(countExamples(false), 0);
+});
+
+test.serial("importFromCSV writes to valid.jsonl when isEval is true", (t) => {
+  const csvPath = join(TEST_DIR, "in.csv");
+  writeFileSync(csvPath, "input,output\nq,a\n");
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX, true);
+
+  t.is(result.imported, 1);
+  t.is(countExamples(true), 1);
+  t.is(countExamples(false), 0);
+});
+
+test.serial("importFromJSON writes to valid.jsonl when isEval is true", (t) => {
+  const jsonPath = join(TEST_DIR, "in.json");
+  writeFileSync(jsonPath, JSON.stringify([{ input: "q", output: "a" }]));
+
+  const result = importFromJSON(jsonPath, SYSTEM_CTX, true);
+
+  t.is(result.imported, 1);
+  t.is(countExamples(true), 1);
+  t.is(countExamples(false), 0);
+});
+
+test.serial("importFromJSONL preserves a messages array into valid.jsonl", (t) => {
+  const jsonlPath = join(TEST_DIR, "in.jsonl");
+  writeFileSync(
+    jsonlPath,
+    `${JSON.stringify({
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "q" },
+        { role: "assistant", content: "a" },
+      ],
+    })}\n`,
+  );
+
+  const result = importFromJSONL(jsonlPath, SYSTEM_CTX, true);
+
+  t.is(result.imported, 1);
+  t.is(loadTrainingData(true)[0].messages[1].content, "q");
+  t.is(countExamples(false), 0);
+});
+
+test.serial("importData routes to the validation set when isEval is true", (t) => {
+  const jsonlPath = join(TEST_DIR, "in.jsonl");
+  writeFileSync(
+    jsonlPath,
+    `${JSON.stringify({ input: "q", output: "a" })}\n`,
+  );
+
+  importData(jsonlPath, SYSTEM_CTX, true);
+
+  t.is(countExamples(true), 1);
+  t.is(countExamples(false), 0);
+});
+
+test.serial("importData still defaults to the training set", (t) => {
+  const jsonlPath = join(TEST_DIR, "in.jsonl");
+  writeFileSync(
+    jsonlPath,
+    `${JSON.stringify({ input: "q", output: "a" })}\n`,
+  );
+
+  importData(jsonlPath, SYSTEM_CTX);
+
+  t.is(countExamples(false), 1);
+  t.is(countExamples(true), 0);
+});

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -1243,17 +1243,24 @@ test.serial("ensureValidationSet reports counts that account for every example",
 });
 
 test.serial("ensureValidationSet forwards its seed to the split", (t) => {
+  // Compared against splitTrainValidation with the same seed rather than
+  // against a second seeded run: two runs agreeing only shows the seed is
+  // used, and with a 2-of-20 split they would agree by chance often enough
+  // for a dropped seed to slip through.
   seedExamples(20);
   ensureValidationSet(42);
-  const firstValid = loadTrainingData(true).map((ex) => ex.messages[1].content);
+  const viaEnsure = loadTrainingData(true).map((ex) => ex.messages[1].content);
 
   rmSync(DATA_DIR, { recursive: true, force: true });
   mkdirSync(DATA_DIR, { recursive: true });
   seedExamples(20);
-  ensureValidationSet(42);
-  const secondValid = loadTrainingData(true).map((ex) => ex.messages[1].content);
+  splitTrainValidation(0.1, 42);
+  const viaSplit = loadTrainingData(true).map((ex) => ex.messages[1].content);
 
-  t.deepEqual(firstValid, secondValid);
+  t.deepEqual(viaEnsure, viaSplit);
+  // A split that shuffled differently would still land 2 examples in valid,
+  // so assert the contents are not merely the same size.
+  t.is(viaEnsure.length, 2);
 });
 
 test.serial("ensureValidationSet returns zero counts with no data at all", (t) => {
@@ -1262,6 +1269,36 @@ test.serial("ensureValidationSet returns zero counts with no data at all", (t) =
   t.false(result.didSplit);
   t.is(result.trainCount, 0);
   t.is(result.validCount, 0);
+});
+
+test.serial(
+  "ensureValidationSet does not report a split that produced no validation examples",
+  (t) => {
+    // One example cannot be split, so valid.jsonl stays empty and every later
+    // call re-enters the same branch. Reporting didSplit here would repeat
+    // "Split 1 examples into 1 train / 0 validation." on every train run.
+    seedExamples(1);
+
+    const first = ensureValidationSet(1);
+
+    t.false(first.didSplit);
+    t.is(first.trainCount, 1);
+    t.is(first.validCount, 0);
+
+    const second = ensureValidationSet(1);
+
+    t.false(second.didSplit);
+  },
+);
+
+test.serial("ensureValidationSet splits at the two-example boundary", (t) => {
+  seedExamples(2);
+
+  const result = ensureValidationSet(1);
+
+  t.true(result.didSplit);
+  t.is(result.trainCount, 1);
+  t.is(result.validCount, 1);
 });
 
 // ── isEval imports ────────────────────────────────────────────────────
@@ -1334,6 +1371,43 @@ test.serial("importData routes to the validation set when isEval is true", (t) =
   t.is(countExamples(true), 1);
   t.is(countExamples(false), 0);
 });
+
+// ── validateTrainingData --eval ─────────────────────────────────
+
+test.serial("validateTrainingData reads the validation set when isEval is true", (t) => {
+  seedExamples(10);
+  ensureValidationSet(1);
+
+  // After a split the training set alone is not the whole picture; validating
+  // it silently would report on 9 of the 10 examples.
+  t.true(validateTrainingData(SYSTEM_CTX, true).valid);
+  t.true(validateTrainingData(SYSTEM_CTX, false).valid);
+});
+
+test.serial("validateTrainingData reports an empty validation set distinctly", (t) => {
+  seedExamples(10);
+
+  const result = validateTrainingData(SYSTEM_CTX, true);
+
+  t.false(result.valid);
+  t.deepEqual(result.errors, ["No validation data found"]);
+});
+
+test.serial(
+  "validateTrainingData does not apply the 50-example floor to the validation set",
+  (t) => {
+    seedExamples(10);
+    ensureValidationSet(1);
+
+    // A validation set is a slice of the training data, so "recommend at
+    // least 50" would fire on every correctly sized split.
+    const evalResult = validateTrainingData(SYSTEM_CTX, true);
+    t.false(evalResult.warnings.some((w) => w.includes("at least 50")));
+
+    const trainResult = validateTrainingData(SYSTEM_CTX, false);
+    t.true(trainResult.warnings.some((w) => w.includes("at least 50")));
+  },
+);
 
 test.serial("importData still defaults to the training set", (t) => {
   const jsonlPath = join(TEST_DIR, "in.jsonl");

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -196,17 +196,20 @@ export interface ValidationResult {
 
 export function validateTrainingData(
 	contextMessage: ChatMessage,
+	isEval = false,
 ): ValidationResult {
 	const errors: string[] = [];
 	const warnings: string[] = [];
-	const examples = loadTrainingData();
+	const examples = loadTrainingData(isEval);
 
 	if (examples.length === 0) {
-		errors.push('No training data found');
+		errors.push(isEval ? 'No validation data found' : 'No training data found');
 		return {valid: false, errors, warnings};
 	}
 
-	if (examples.length < 50) {
+	// A validation set is a slice of the training data, so the 50-example floor
+	// does not apply to it - warning about it would be noise on a correct split.
+	if (!isEval && examples.length < 50) {
 		warnings.push(
 			`Only ${examples.length} examples found. Recommend at least 50 for good results.`,
 		);
@@ -820,8 +823,12 @@ export function ensureValidationSet(seed?: number): {
 	const trainCount = countExamples(false);
 
 	if (validCount === 0 && trainCount > 0) {
-		// No validation set - create one by splitting
-		return {...splitTrainValidation(0.1, seed), didSplit: true};
+		// No validation set - create one by splitting.
+		const result = splitTrainValidation(0.1, seed);
+		// A single example cannot be split, so valid.jsonl stays empty and the
+		// next call lands here again. Reporting didSplit for that no-op would
+		// repeat "Split 1 examples into 1 train / 0 validation." on every run.
+		return {...result, didSplit: result.validCount > 0};
 	}
 
 	return {trainCount, validCount, didSplit: false};

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -466,6 +466,7 @@ export function parseCSV(content: string): string[][] {
 export function importFromCSV(
 	filePath: string,
 	contextMessage: ChatMessage,
+	isEval = false,
 ): ImportResult {
 	const errors: string[] = [];
 	let imported = 0;
@@ -504,11 +505,14 @@ export function importFromCSV(
 			continue;
 		}
 
-		appendToTrainingData({
-			contextMessage,
-			userInput: input.trim(),
-			assistantOutput: output.trim(),
-		});
+		appendToTrainingData(
+			{
+				contextMessage,
+				userInput: input.trim(),
+				assistantOutput: output.trim(),
+			},
+			isEval,
+		);
 		imported++;
 	}
 
@@ -518,6 +522,7 @@ export function importFromCSV(
 export function importFromJSONL(
 	filePath: string,
 	contextMessage: ChatMessage,
+	isEval = false,
 ): ImportResult {
 	const errors: string[] = [];
 	let imported = 0;
@@ -541,7 +546,7 @@ export function importFromJSONL(
 					);
 
 					if (userMsg?.content && assistantMsg?.content) {
-						appendTrainingExample({messages: data.messages}, false);
+						appendTrainingExample({messages: data.messages}, isEval);
 						imported++;
 						continue;
 					}
@@ -554,11 +559,14 @@ export function importFromJSONL(
 
 			// Simple {input, output} format — wrap with the project context.
 			if (data.input && data.output) {
-				appendToTrainingData({
-					contextMessage,
-					userInput: data.input,
-					assistantOutput: data.output,
-				});
+				appendToTrainingData(
+					{
+						contextMessage,
+						userInput: data.input,
+						assistantOutput: data.output,
+					},
+					isEval,
+				);
 				imported++;
 				continue;
 			}
@@ -577,6 +585,7 @@ export function importFromJSONL(
 export function importFromJSON(
 	filePath: string,
 	contextMessage: ChatMessage,
+	isEval = false,
 ): ImportResult {
 	const errors: string[] = [];
 	let imported = 0;
@@ -600,7 +609,7 @@ export function importFromJSON(
 			);
 
 			if (userMsg?.content && assistantMsg?.content) {
-				appendTrainingExample({messages: item.messages}, false);
+				appendTrainingExample({messages: item.messages}, isEval);
 				imported++;
 				continue;
 			}
@@ -611,11 +620,14 @@ export function importFromJSON(
 		}
 
 		if (item.input && item.output) {
-			appendToTrainingData({
-				contextMessage,
-				userInput: item.input,
-				assistantOutput: item.output,
-			});
+			appendToTrainingData(
+				{
+					contextMessage,
+					userInput: item.input,
+					assistantOutput: item.output,
+				},
+				isEval,
+			);
 			imported++;
 			continue;
 		}
@@ -630,6 +642,7 @@ export function importFromJSON(
 export function importData(
 	filePath: string,
 	contextMessage: ChatMessage,
+	isEval = false,
 ): ImportResult {
 	if (!existsSync(filePath)) {
 		return {imported: 0, skipped: 0, errors: ['File not found']};
@@ -639,11 +652,11 @@ export function importData(
 
 	switch (ext) {
 		case 'csv':
-			return importFromCSV(filePath, contextMessage);
+			return importFromCSV(filePath, contextMessage, isEval);
 		case 'jsonl':
-			return importFromJSONL(filePath, contextMessage);
+			return importFromJSONL(filePath, contextMessage, isEval);
 		case 'json':
-			return importFromJSON(filePath, contextMessage);
+			return importFromJSON(filePath, contextMessage, isEval);
 		default:
 			return {
 				imported: 0,
@@ -801,14 +814,15 @@ export function splitTrainValidation(
 export function ensureValidationSet(seed?: number): {
 	trainCount: number;
 	validCount: number;
+	didSplit: boolean;
 } {
 	const validCount = countExamples(true);
 	const trainCount = countExamples(false);
 
 	if (validCount === 0 && trainCount > 0) {
 		// No validation set - create one by splitting
-		return splitTrainValidation(0.1, seed);
+		return {...splitTrainValidation(0.1, seed), didSplit: true};
 	}
 
-	return {trainCount, validCount};
+	return {trainCount, validCount, didSplit: false};
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -354,7 +354,10 @@ export function fixContextMessages(
 		if (!first || first.role === 'user' || first.role === 'assistant') {
 			return ex;
 		}
-		if (first.role === contextMessage.role && first.content === contextMessage.content) {
+		if (
+			first.role === contextMessage.role &&
+			first.content === contextMessage.content
+		) {
 			return ex;
 		}
 		fixedCount++;
@@ -720,7 +723,9 @@ export function exportToCSV(filePath: string, isEval = false): ExportResult {
 		const assistant = ex.messages.find(m => m.role === 'assistant');
 		if (!user?.content || !assistant?.content) {
 			skipped++;
-			errors.push(`Example ${i + 1}: missing user or assistant message, skipped`);
+			errors.push(
+				`Example ${i + 1}: missing user or assistant message, skipped`,
+			);
 			return;
 		}
 


### PR DESCRIPTION
Closes #63

## Description

Makes the train/validation split visible, inspectable and reproducible.

**The split announces itself.** `ensureValidationSet()` now returns `didSplit`, so `train` can distinguish a fresh split from a no-op and report it:


Showing both counts side by side means the number never appears to drop the 10 missing examples are accounted for on the same screen. `didSplit` means "a validation set now exists", not "the split branch ran", so a single example which cannot be split does not report one on every run.

**The validation set is reachable.** `--eval` on `data list`, `data add`, `data import` and `data validate` points them at `valid.jsonl`, and `status` reports the two counts separately. `data list` also shows the other set's size (`90 examples (+10 validation)`), so the split is explained there too. `data validate --eval` skips the "recommend at least 50 examples" warning, since a correct 10% split is always under that floor.

`isEval` is threaded through `importData` → `importFromCSV` / `importFromJSONL` / `importFromJSON` and through `validateTrainingData` as a defaulted parameter, so every existing call site behaves exactly as before.

**Splits are reproducible.** `nanotune train --seed <n>` reaches the seed that `splitTrainValidation` and `ensureValidationSet` already accepted. Non-integer seeds are rejected rather than coerced, and a seed passed to an already-split project says so instead of silently doing nothing.

**A dry run stays a dry run.** `ensureValidationSet()` now runs after the `--dry-run` early return, so a command documented as "validate config without training" leaves `train.jsonl` and `valid.jsonl` exactly as it found them.

Two deliberate omissions:

- I used a `--seed` flag rather than a config field — no schema change or migration, and it shows up in `--help`. A `training.seed` key would layer on cleanly later if that's preferred.
- The split ratio stays hardcoded at 0.1. The issue lists it as "consider", and where it should live (config vs. flag) is a separate call.

> One commit here is unrelated to the feature. `test:lint` was failing in CI on four findings that predate this branch and are present on `main` the `.option()` wrap in `data export`, the `mergeEditedTurn` call in `data/list.tsx`, two spots in `data.ts`, and the import order in `data/validate.tsx`. They surface under the biome version the lockfile pins. That commit is formatter output only (`biome check --write`; `git diff -w` shows the same change set). It gets this PR green, but `main` is still red on `test:lint` worth a `pnpm format` separately.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [x] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)