### PR TITLE
fix: strip the UTF-8 BOM when parsing CSV

### DIFF
--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -603,6 +603,15 @@ test("parseCSV drops only trailing entirely-empty rows", (t) => {
   ]);
 });
 
+test("parseCSV strips a leading UTF-8 BOM", (t) => {
+  // Excel writes a BOM ahead of the first cell; left in place the header
+  // reads "\uFEFFinput" and stops matching a plain "input" header.
+  t.deepEqual(parseCSV("\uFEFFinput,output\na,b"), [
+    ["input", "output"],
+    ["a", "b"],
+  ]);
+});
+
 test("importFromCSV correctly imports a row with an embedded comma", (t) => {
   const csvPath = join(TEST_DIR, "embed.csv");
   // Regression test: the old regex rejected this; the new state-machine
@@ -616,6 +625,19 @@ test("importFromCSV correctly imports a row with an embedded comma", (t) => {
   const data = loadTrainingData();
   t.is(data[0].messages[1].content, "please list files, recursively");
   t.is(data[0].messages[2].content, "find .");
+});
+
+test.serial("importFromCSV skips the header row of a BOM-prefixed file", (t) => {
+  const csvPath = join(TEST_DIR, "bom-header.csv");
+  writeFileSync(csvPath, '\uFEFFinput,output\n"list files","ls"\n');
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 1);
+  t.is(result.skipped, 0);
+
+  const data = loadTrainingData();
+  t.is(data.length, 1);
+  t.is(data[0].messages[1].content, "list files");
 });
 
 // ── splitTrainValidation seedability ──────────────────────────────────

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -264,6 +264,7 @@ export interface ImportResult {
  * Parse a CSV file into an array of row arrays. Supports:
  *  - Quoted fields with embedded commas, newlines, and escaped quotes ("")
  *  - Unquoted fields
+ *  - A leading UTF-8 BOM, as written by Excel and other spreadsheet tools
  *  - CRLF or LF line endings
  */
 export function parseCSV(content: string): string[][] {
@@ -271,7 +272,7 @@ export function parseCSV(content: string): string[][] {
 	let field = '';
 	let row: string[] = [];
 	let inQuotes = false;
-	let i = 0;
+	let i = content.startsWith('\uFEFF') ? 1 : 0;
 
 	while (i < content.length) {
 		const ch = content[i];


### PR DESCRIPTION
## Description

Spreadsheet tools such as Excel prefix exported UTF-8 CSVs with a byte order mark. parseCSV treated it as ordinary text, so the first cell of the first row came back as "\uFEFFinput" instead of "input".

Header detection survived this only because it matches with includes(); any move to exact equality would have silently treated the header row as training data. Skip the BOM at the start of the parse instead.

Closes #87

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed) — not needed; the behaviour is internal to the
      parser. The `parseCSV` docblock gained one line noting BOM handling.
- [x] No breaking changes (or clearly documented)
