### PR TITLE
fix: keep quote characters distinct when matching benchmark answers

### DIFF
--- a/src/lib/benchmark-match.spec.ts
+++ b/src/lib/benchmark-match.spec.ts
@@ -7,8 +7,8 @@ test("normalizeText collapses runs of whitespace to a single space", (t) => {
   t.is(normalizeText("a   b\t\tc"), "a b c");
 });
 
-test("normalizeText canonicalizes quote characters to double quotes", (t) => {
-  t.is(normalizeText("it's a `test`"), 'it"s a "test"');
+test("normalizeText preserves quote characters", (t) => {
+  t.is(normalizeText("it's a `test`"), "it's a `test`");
 });
 
 test("normalizeText trims leading and trailing whitespace", (t) => {
@@ -134,10 +134,26 @@ test("checkPass defaults to semantic mode when no mode is passed", (t) => {
   t.false(checkPass(["ls -la"], "ls").passed);
 });
 
-test("checkPass semantic ignores quote-style differences via normalizeText", (t) => {
-  // "she said 'hello'" should match acceptable `she said "hello"` because
-  // normalizeText canonicalizes quote characters.
-  t.true(
-    checkPass(['she said "hello"'], "she said 'hello'", "semantic").passed,
-  );
+// ── quote handling (regression) ───────────────────────────────────────
+
+test("checkPass semantic REJECTS a single-quoted answer when double quotes are expected", (t) => {
+  // normalizeText used to flatten ' and ` into ", so any quote style passed.
+  const result = checkPass(['echo "hi"'], "echo 'hi'", "semantic");
+  t.false(result.passed);
+  t.is(result.matchType, null);
+});
+
+test("checkPass semantic REJECTS backticks when double quotes are expected", (t) => {
+  // Backticks are command substitution in bash and a code span in markdown.
+  t.false(checkPass(['echo "hi"'], "echo `hi`", "semantic").passed);
+});
+
+test("checkPass semantic accepts an answer whose quote style matches", (t) => {
+  t.true(checkPass(["echo 'hi'"], "echo 'hi'", "semantic").passed);
+  t.true(checkPass(["echo `hi`"], "echo `hi`", "semantic").passed);
+});
+
+test("checkPass contains is quote-sensitive", (t) => {
+  t.false(checkPass(["'single'"], 'wrapped in "single" here', "contains").passed);
+  t.true(checkPass(["'single'"], "wrapped in 'single' here", "contains").passed);
 });

--- a/src/lib/benchmark-match.ts
+++ b/src/lib/benchmark-match.ts
@@ -4,10 +4,9 @@ import type {MatchMode} from '../types/index.js';
  * Normalize text for comparison:
  * - trim whitespace
  * - collapse runs of whitespace to a single space
- * - canonicalize different quote characters to `"`
  */
 export function normalizeText(text: string): string {
-	return text.trim().replace(/\s+/g, ' ').replace(/["'`]/g, '"');
+	return text.trim().replace(/\s+/g, ' ');
 }
 
 /**


### PR DESCRIPTION
Closes #85

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init` 
- [x] Tested `nanotune data`
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`) — biome clean on the changed file.
- [x] Self-review completed
- [ ] Documentation updated (if needed) — no doc mentions the quote canonicalization; the
      stale CHANGELOG line is historical and left as-is.
- [x] No breaking changes (or clearly documented)