### PR TITLE
fix: match CSV header names exactly instead of by substring

### DIFF
--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -221,6 +221,32 @@ test.serial("importFromCSV imports valid rows with context message role", (t) =>
   t.is(data[0].messages[2].content, "ls");
 });
 
+test.serial("importFromCSV keeps a first row that merely mentions input", (t) => {
+  const csvPath = join(TEST_DIR, "keyword.csv");
+  writeFileSync(
+    csvPath,
+    '"explain the input parameter","it configures the stream"\n"second row","second output"\n',
+  );
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 2);
+  t.is(result.skipped, 0);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages[1].content, "explain the input parameter");
+});
+
+test.serial("importFromCSV still skips a real header row", (t) => {
+  const csvPath = join(TEST_DIR, "header.csv");
+  writeFileSync(csvPath, 'Input , Output\n"list files","ls"\n');
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 1);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages[1].content, "list files");
+});
+
 test.serial("importFromCSV skips invalid lines", (t) => {
   const csvPath = join(TEST_DIR, "bad.csv");
   writeFileSync(csvPath, "\"good\",\"data\"\nthis has no comma separation at all really\n");

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -247,6 +247,18 @@ test.serial("importFromCSV still skips a real header row", (t) => {
   t.is(data[0].messages[1].content, "list files");
 });
 
+test.serial("importFromCSV does not treat a partial header match as a header", (t) => {
+  const csvPath = join(TEST_DIR, "partial-header.csv");
+  writeFileSync(csvPath, 'input,"not a header"\n"x","y"\n');
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 2);
+  t.is(result.skipped, 0);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages[1].content, "input");
+});
+
 test.serial("importFromCSV skips invalid lines", (t) => {
   const csvPath = join(TEST_DIR, "bad.csv");
   writeFileSync(csvPath, "\"good\",\"data\"\nthis has no comma separation at all really\n");

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -257,6 +257,28 @@ test.serial("importFromCSV does not treat a partial header match as a header", (
 
   const data = loadTrainingData();
   t.is(data[0].messages[1].content, "input");
+  t.is(data[0].messages[2].content, "not a header");
+});
+
+test.serial("importFromCSV reports a one-column first row instead of skipping it", (t) => {
+  const csvPath = join(TEST_DIR, "one-column.csv");
+  writeFileSync(csvPath, "input\n\"list files\",\"ls\"\n");
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 1);
+  t.is(result.skipped, 1);
+  t.is(result.errors.length, 1);
+});
+
+test.serial("importFromCSV skips a header row that has extra columns", (t) => {
+  const csvPath = join(TEST_DIR, "wide-header.csv");
+  writeFileSync(csvPath, 'input,output,notes\n"list files","ls","shell"\n');
+
+  const result = importFromCSV(csvPath, SYSTEM_CTX);
+  t.is(result.imported, 1);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages[1].content, "list files");
 });
 
 test.serial("importFromCSV skips invalid lines", (t) => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -361,11 +361,11 @@ export function importFromCSV(
 		return {imported, skipped, errors};
 	}
 
-	// Skip header if first row looks like one
-	const firstRowLower = rows[0].map(c => c.toLowerCase());
+	// Skip header if first row looks like one. Match the column names exactly:
+	// a substring match drops real rows that happen to mention input or output.
+	const firstRowLower = rows[0].map(c => c.trim().toLowerCase());
 	const hasHeader =
-		firstRowLower.some(c => c.includes('input')) ||
-		firstRowLower.some(c => c.includes('output'));
+		firstRowLower[0] === 'input' || firstRowLower[1] === 'output';
 	const startIndex = hasHeader ? 1 : 0;
 
 	for (let i = startIndex; i < rows.length; i++) {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -361,11 +361,14 @@ export function importFromCSV(
 		return {imported, skipped, errors};
 	}
 
-	// Skip header if first row looks like one. Match the column names exactly:
-	// a substring match drops real rows that happen to mention input or output.
+	// Skip the first row only when it is exactly the two column names. Matching
+	// loosely — by substring, or on either column alone — silently drops real
+	// rows such as `"explain the input parameter","..."` or `"input","a value"`.
 	const firstRowLower = rows[0].map(c => c.trim().toLowerCase());
 	const hasHeader =
-		firstRowLower[0] === 'input' || firstRowLower[1] === 'output';
+		firstRowLower.length >= 2 &&
+		firstRowLower[0] === 'input' &&
+		firstRowLower[1] === 'output';
 	const startIndex = hasHeader ? 1 : 0;
 
 	for (let i = startIndex; i < rows.length; i++) {


### PR DESCRIPTION
Fixes #81.

`importFromCSV` treated the first row as a header whenever any cell contained the substring `input` or `output`, so a real training row got dropped with no error:

```
"explain the input parameter","it configures the stream"
"second row","second output"
```

```
imported: 1   (expected 2)
```

Compares the trimmed, lowercased cells against the column names instead of substring-matching them. `Input , Output` is still detected as a header.

Two tests in `data.spec.ts` — one for the dropped row, one confirming real headers are still skipped. The first fails on main.

`pnpm test:lint`, `test:types`, `test:knip` and `test:ava` all pass (241).
