### PR TITLE
feat: add benchmark comparison and base-model control

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -160,10 +160,14 @@ program
 	});
 
 // Benchmark command
-program
+const benchmarkCommand = program
 	.command('benchmark')
 	.description('Run benchmarks against a test dataset')
 	.option('-m, --model <path>', 'Path to model file')
+	.option(
+		'--base',
+		'Benchmark the base (pre-fine-tuning) model as a control, caching the quantized GGUF for reuse',
+	)
 	.option('-d, --dataset <path>', 'Path to benchmark dataset')
 	.option('-t, --timeout <ms>', 'Timeout per test in milliseconds')
 	.option(
@@ -190,6 +194,16 @@ program
 	.action(async options => {
 		const {BenchmarkCommand} = await import('./commands/benchmark.js');
 		render(<BenchmarkCommand options={options} />);
+	});
+
+benchmarkCommand
+	.command('compare [fileA] [fileB]')
+	.description('Compare two saved benchmark runs')
+	.action(async (fileA?: string, fileB?: string) => {
+		const {BenchmarkCompareCommand} = await import(
+			'./commands/benchmark/compare.js'
+		);
+		render(<BenchmarkCompareCommand fileA={fileA} fileB={fileB} />);
 	});
 
 // Chat command

--- a/src/commands/benchmark.tsx
+++ b/src/commands/benchmark.tsx
@@ -48,7 +48,10 @@ import {
 	stopLlamaServer,
 } from '../lib/llama-cpp.js';
 import {ensureModelDownloaded} from '../lib/mlx.js';
-import {getBaseModelCachePath} from '../lib/model-cache.js';
+import {
+	getBaseModelCachePath,
+	sweepStaleCacheArtifacts,
+} from '../lib/model-cache.js';
 import {assertSupportedPlatform} from '../lib/platform.js';
 import {
 	BENCHMARK_PRESETS,
@@ -57,7 +60,6 @@ import {
 	type BenchmarkTest,
 	type BenchmarkTestResult,
 	type JudgeProviderConfig,
-	type QuantizationType,
 } from '../types/index.js';
 
 interface Props {
@@ -301,7 +303,7 @@ export function BenchmarkCommand({options}: Props) {
 				// download/convert/quantize run.
 				assertSupportedPlatform();
 
-				const quantization = config.export.quantization as QuantizationType;
+				const quantization = config.export.quantization;
 				const cachePath = getBaseModelCachePath(config.baseModel, quantization);
 
 				if (!existsSync(cachePath)) {
@@ -337,7 +339,9 @@ export function BenchmarkCommand({options}: Props) {
 						})(),
 					]);
 					if (!snapshotPath) {
-						throw new Error('Could not resolve the downloaded base model path.');
+						throw new Error(
+							'Could not resolve the downloaded base model path.',
+						);
 					}
 
 					// Export to a temp path and rename into place atomically.
@@ -346,6 +350,9 @@ export function BenchmarkCommand({options}: Props) {
 					// file landed directly at cachePath, every future run would
 					// silently treat that corrupt file as a valid cache hit.
 					mkdirSync(dirname(cachePath), {recursive: true});
+					// Clean up .tmp-<pid>.gguf / -f16.gguf leftovers from a previous
+					// run that was interrupted before its own cleanup could run.
+					sweepStaleCacheArtifacts(dirname(cachePath));
 					const tempCachePath = cachePath.replace(
 						/\.gguf$/,
 						`.tmp-${process.pid}.gguf`,
@@ -778,11 +785,7 @@ export function BenchmarkCommand({options}: Props) {
 			<Header title="Benchmark" />
 
 			{status === 'loading' && (
-				<Box flexDirection="column">
-					<Spinner
-						label={prepStep ?? 'Loading benchmark data...'}
-					/>
-				</Box>
+				<Spinner label={prepStep ?? 'Loading benchmark data...'} />
 			)}
 
 			{status === 'running' && (

--- a/src/commands/benchmark.tsx
+++ b/src/commands/benchmark.tsx
@@ -1,5 +1,12 @@
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
-import {join} from 'node:path';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {dirname, join} from 'node:path';
 import {Spinner, StatusMessage} from '@inkjs/ui';
 import {Box, Text, useApp} from 'ink';
 import {useCallback, useEffect, useState} from 'react';
@@ -32,11 +39,17 @@ import {
 } from '../lib/judge.js';
 import {
 	chatCompletion,
+	checkLlamaCppInstalled,
+	exportModel,
 	type GenerateOptions,
+	installLlamaCpp,
 	type ServerOptions,
 	startLlamaServer,
 	stopLlamaServer,
 } from '../lib/llama-cpp.js';
+import {ensureModelDownloaded} from '../lib/mlx.js';
+import {getBaseModelCachePath} from '../lib/model-cache.js';
+import {assertSupportedPlatform} from '../lib/platform.js';
 import {
 	BENCHMARK_PRESETS,
 	type BenchmarkPreset,
@@ -44,11 +57,13 @@ import {
 	type BenchmarkTest,
 	type BenchmarkTestResult,
 	type JudgeProviderConfig,
+	type QuantizationType,
 } from '../types/index.js';
 
 interface Props {
 	options: {
 		model?: string;
+		base?: boolean;
 		dataset?: string;
 		timeout?: string;
 		preset?: string;
@@ -80,6 +95,9 @@ function generateMarkdownReport(
 	lines.push('');
 	lines.push(`**Date:** ${new Date(result.timestamp).toLocaleString()}`);
 	lines.push(`**Model:** ${result.model.split('/').pop()}`);
+	lines.push(
+		`**Run Type:** ${result.isBase ? 'Base model (control)' : 'Fine-tuned'}`,
+	);
 	lines.push('');
 
 	// Summary
@@ -221,6 +239,7 @@ export function BenchmarkCommand({options}: Props) {
 	const {exit} = useApp();
 	const [status, setStatus] = useState<Status>('loading');
 	const [error, setError] = useState<string | null>(null);
+	const [prepStep, setPrepStep] = useState<string | null>(null);
 	const [currentTest, setCurrentTest] = useState<string | null>(null);
 	const [progress, setProgress] = useState(0);
 	const [results, setResults] = useState<BenchmarkResult | null>(null);
@@ -250,20 +269,111 @@ export function BenchmarkCommand({options}: Props) {
 				role: 'system',
 				content: '',
 			};
+			let config: ReturnType<typeof loadConfig> | null = null;
 			try {
-				const config = loadConfig();
+				config = loadConfig();
 				contextMsg = resolveContextMessage(config);
 			} catch {
 				// Minimal config (e.g., external benchmark runner) — no context message needed
 			}
 			const benchmarksDir = getBenchmarksDir();
 
-			// Find model
-			let modelPath = options.model ?? findLatestGGUF();
-			if (!modelPath) {
-				setError('No exported models found. Run `nanotune export` first.');
+			if (options.model && options.base) {
+				setError(
+					'`--model` and `--base` are mutually exclusive — `--base` resolves the model itself.',
+				);
 				setStatus('error');
 				return;
+			}
+
+			// Find model
+			let modelPath: string | null;
+			if (options.base) {
+				if (!config) {
+					setError(
+						'`--base` requires a full nanotune config with `baseModel` set. Run `nanotune init` first, or omit `--base` and pass `--model` directly.',
+					);
+					setStatus('error');
+					return;
+				}
+
+				// Fail fast on unsupported hardware before a multi-minute
+				// download/convert/quantize run.
+				assertSupportedPlatform();
+
+				const quantization = config.export.quantization as QuantizationType;
+				const cachePath = getBaseModelCachePath(config.baseModel, quantization);
+
+				if (!existsSync(cachePath)) {
+					// Installing llama.cpp and downloading the base model are
+					// independent — run them concurrently instead of waiting on
+					// one before starting the other.
+					const [, snapshotPath] = await Promise.all([
+						(async () => {
+							const hasLlamaCpp = await checkLlamaCppInstalled();
+							if (!hasLlamaCpp) {
+								setPrepStep('Installing llama.cpp...');
+								for await (const msg of installLlamaCpp()) {
+									setPrepStep(msg);
+								}
+							}
+						})(),
+						(async (): Promise<string | undefined> => {
+							setPrepStep(`Downloading base model ${config.baseModel}...`);
+							let resolvedPath: string | undefined;
+							for await (const progress of ensureModelDownloaded(
+								config.baseModel,
+							)) {
+								setPrepStep(
+									progress.sizeInfo
+										? `Downloading base model... ${progress.sizeInfo}`
+										: 'Downloading base model...',
+								);
+								if (progress.path) {
+									resolvedPath = progress.path;
+								}
+							}
+							return resolvedPath;
+						})(),
+					]);
+					if (!snapshotPath) {
+						throw new Error('Could not resolve the downloaded base model path.');
+					}
+
+					// Export to a temp path and rename into place atomically.
+					// existsSync(cachePath) above is the only thing gating reuse of
+					// this cache — if a run gets killed mid-quantize and the partial
+					// file landed directly at cachePath, every future run would
+					// silently treat that corrupt file as a valid cache hit.
+					mkdirSync(dirname(cachePath), {recursive: true});
+					const tempCachePath = cachePath.replace(
+						/\.gguf$/,
+						`.tmp-${process.pid}.gguf`,
+					);
+					try {
+						for await (const progress of exportModel(
+							snapshotPath,
+							tempCachePath,
+							quantization,
+						)) {
+							setPrepStep(progress.step);
+						}
+						renameSync(tempCachePath, cachePath);
+					} finally {
+						if (existsSync(tempCachePath)) {
+							rmSync(tempCachePath, {force: true});
+						}
+					}
+				}
+
+				modelPath = cachePath;
+			} else {
+				modelPath = options.model ?? findLatestGGUF();
+				if (!modelPath) {
+					setError('No exported models found. Run `nanotune export` first.');
+					setStatus('error');
+					return;
+				}
 			}
 
 			if (!existsSync(modelPath)) {
@@ -596,6 +706,7 @@ export function BenchmarkCommand({options}: Props) {
 			const finalResult: BenchmarkResult = {
 				model: modelPath,
 				timestamp: new Date().toISOString(),
+				isBase: Boolean(options.base),
 				summary: {
 					total: totalTests,
 					passed: totalPassed,
@@ -633,6 +744,7 @@ export function BenchmarkCommand({options}: Props) {
 		}
 	}, [
 		options.model,
+		options.base,
 		options.dataset,
 		options.timeout,
 		options.preset,
@@ -665,7 +777,13 @@ export function BenchmarkCommand({options}: Props) {
 		<Box flexDirection="column" padding={1}>
 			<Header title="Benchmark" />
 
-			{status === 'loading' && <Spinner label="Loading benchmark data..." />}
+			{status === 'loading' && (
+				<Box flexDirection="column">
+					<Spinner
+						label={prepStep ?? 'Loading benchmark data...'}
+					/>
+				</Box>
+			)}
 
 			{status === 'running' && (
 				<Box flexDirection="column">
@@ -706,6 +824,7 @@ export function BenchmarkCommand({options}: Props) {
 					<Text> </Text>
 					<Text>
 						Model: <Text color="cyan">{results.model.split('/').pop()}</Text>
+						{results.isBase && <Text dimColor> (base model, control)</Text>}
 					</Text>
 					<Text>
 						Score:{' '}

--- a/src/commands/benchmark/compare.spec.ts
+++ b/src/commands/benchmark/compare.spec.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "ava";
+import { orderByMtime, resolveComparisonPair } from "./compare.js";
+
+const ORIG_CWD = process.cwd();
+const TEST_DIR = join(ORIG_CWD, ".test-compare-spec");
+const BENCH_DIR = join(TEST_DIR, ".nanotune", "benchmarks");
+
+function setup() {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BENCH_DIR, { recursive: true });
+  process.chdir(TEST_DIR);
+}
+
+function teardown() {
+  process.chdir(ORIG_CWD);
+  rmSync(TEST_DIR, { recursive: true, force: true });
+}
+
+function writeBenchmark(filename: string, ageMs: number): string {
+  const path = join(BENCH_DIR, filename);
+  writeFileSync(path, "{}");
+  const mtime = new Date(Date.now() - ageMs);
+  utimesSync(path, mtime, mtime);
+  return path;
+}
+
+// ── orderByMtime ──────────────────────────────────────────────────────
+
+test.serial("orderByMtime puts the older file first regardless of argument order", (t) => {
+  setup();
+  try {
+    const older = writeBenchmark("benchmark-older.json", 60_000);
+    const newer = writeBenchmark("benchmark-newer.json", 0);
+
+    t.deepEqual(orderByMtime(older, newer), { beforePath: older, afterPath: newer });
+    t.deepEqual(orderByMtime(newer, older), { beforePath: older, afterPath: newer });
+  } finally {
+    teardown();
+  }
+});
+
+// ── resolveComparisonPair ─────────────────────────────────────────────
+
+test.serial("resolveComparisonPair with 0 args picks the two most recent runs", (t) => {
+  setup();
+  try {
+    writeBenchmark("benchmark-oldest.json", 120_000);
+    const middle = writeBenchmark("benchmark-middle.json", 60_000);
+    const newest = writeBenchmark("benchmark-newest.json", 0);
+
+    const { beforePath, afterPath } = resolveComparisonPair(undefined, undefined);
+    t.is(beforePath, middle);
+    t.is(afterPath, newest);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("resolveComparisonPair with 0 args throws when fewer than two runs exist", (t) => {
+  setup();
+  try {
+    writeBenchmark("benchmark-only.json", 0);
+    t.throws(() => resolveComparisonPair(undefined, undefined));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("resolveComparisonPair with 1 arg compares it against the latest run", (t) => {
+  setup();
+  try {
+    const older = writeBenchmark("benchmark-older.json", 60_000);
+    const latest = writeBenchmark("benchmark-latest.json", 0);
+
+    const { beforePath, afterPath } = resolveComparisonPair("benchmark-older.json", undefined);
+    t.is(beforePath, older);
+    t.is(afterPath, latest);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("resolveComparisonPair with 1 arg falls back to the second-latest when the named run IS the latest", (t) => {
+  setup();
+  try {
+    const secondLatest = writeBenchmark("benchmark-second.json", 60_000);
+    const latest = writeBenchmark("benchmark-latest.json", 0);
+
+    const { beforePath, afterPath } = resolveComparisonPair("benchmark-latest.json", undefined);
+    t.is(beforePath, secondLatest);
+    t.is(afterPath, latest);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("resolveComparisonPair with 1 arg throws when no other run exists to compare against", (t) => {
+  setup();
+  try {
+    writeBenchmark("benchmark-only.json", 0);
+    t.throws(() => resolveComparisonPair("benchmark-only.json", undefined));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("resolveComparisonPair with 2 args preserves the given before/after order", (t) => {
+  setup();
+  try {
+    // Give the "after" arg the older mtime to prove explicit args aren't
+    // reordered by orderByMtime the way the 0/1-arg forms are.
+    const afterArg = writeBenchmark("benchmark-a.json", 60_000);
+    const beforeArg = writeBenchmark("benchmark-b.json", 0);
+
+    const { beforePath, afterPath } = resolveComparisonPair(
+      "benchmark-b.json",
+      "benchmark-a.json",
+    );
+    t.is(beforePath, beforeArg);
+    t.is(afterPath, afterArg);
+  } finally {
+    teardown();
+  }
+});

--- a/src/commands/benchmark/compare.tsx
+++ b/src/commands/benchmark/compare.tsx
@@ -19,6 +19,7 @@ import {
 import {
 	type BenchmarkComparison,
 	compareBenchmarks,
+	deltaColor,
 	formatDelta,
 	formatPercent,
 	generateComparisonMarkdown,
@@ -43,7 +44,7 @@ type Status = 'loading' | 'done' | 'error';
  * earlier state" regardless of which one the caller happened to resolve
  * first.
  */
-function orderByMtime(
+export function orderByMtime(
 	pathX: string,
 	pathY: string,
 ): {beforePath: string; afterPath: string} {
@@ -61,7 +62,7 @@ function orderByMtime(
  *   if the named run IS the latest).
  * - 0 args: the two most recent runs.
  */
-function resolveComparisonPair(
+export function resolveComparisonPair(
 	fileA?: string,
 	fileB?: string,
 ): {beforePath: string; afterPath: string} {
@@ -181,6 +182,7 @@ export function BenchmarkCompareCommand({fileA, fileB}: Props) {
 			<Text>
 				Before:{' '}
 				<Text color="cyan">{comparison.before.model.split('/').pop()}</Text>{' '}
+				{comparison.before.isBase && <Text dimColor>(base, control) </Text>}
 				<Text dimColor>
 					({comparison.before.passed}/{comparison.before.total},{' '}
 					{formatPercent(comparison.before.passRate)})
@@ -189,6 +191,7 @@ export function BenchmarkCompareCommand({fileA, fileB}: Props) {
 			<Text>
 				After:{' '}
 				<Text color="cyan">{comparison.after.model.split('/').pop()}</Text>{' '}
+				{comparison.after.isBase && <Text dimColor>(base, control) </Text>}
 				<Text dimColor>
 					({comparison.after.passed}/{comparison.after.total},{' '}
 					{formatPercent(comparison.after.passRate)})
@@ -197,16 +200,7 @@ export function BenchmarkCompareCommand({fileA, fileB}: Props) {
 			<Text> </Text>
 			<Text>
 				Overall Delta:{' '}
-				<Text
-					bold
-					color={
-						comparison.overallDelta > 0
-							? 'green'
-							: comparison.overallDelta < 0
-								? 'red'
-								: undefined
-					}
-				>
+				<Text bold color={deltaColor(comparison.overallDelta)}>
 					{formatDelta(comparison.overallDelta)}
 				</Text>
 			</Text>

--- a/src/commands/benchmark/compare.tsx
+++ b/src/commands/benchmark/compare.tsx
@@ -1,0 +1,292 @@
+import {
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
+import {join} from 'node:path';
+import {StatusMessage} from '@inkjs/ui';
+import {Box, Text, useApp} from 'ink';
+import {useEffect, useState} from 'react';
+import {
+	DataTable,
+	ExitHint,
+	Header,
+	useAutoExit,
+	useKeyInput,
+} from '../../components/index.js';
+import {
+	type BenchmarkComparison,
+	compareBenchmarks,
+	formatDelta,
+	formatPercent,
+	generateComparisonMarkdown,
+} from '../../lib/benchmark-compare.js';
+import {
+	findLatestBenchmark,
+	getBenchmarksDir,
+	listBenchmarks,
+	loadBenchmark,
+	resolveBenchmarkPath,
+} from '../../lib/config.js';
+
+interface Props {
+	fileA?: string;
+	fileB?: string;
+}
+
+type Status = 'loading' | 'done' | 'error';
+
+/**
+ * Order two run paths chronologically so "before" always reads as "the
+ * earlier state" regardless of which one the caller happened to resolve
+ * first.
+ */
+function orderByMtime(
+	pathX: string,
+	pathY: string,
+): {beforePath: string; afterPath: string} {
+	const mtimeX = statSync(pathX).mtimeMs;
+	const mtimeY = statSync(pathY).mtimeMs;
+	return mtimeX <= mtimeY
+		? {beforePath: pathX, afterPath: pathY}
+		: {beforePath: pathY, afterPath: pathX};
+}
+
+/**
+ * Resolve the pair of runs to compare from 0, 1, or 2 CLI arguments.
+ * - 2 args: explicit before/after, in the order given.
+ * - 1 arg: that run vs. the latest run (falling back to the second-latest
+ *   if the named run IS the latest).
+ * - 0 args: the two most recent runs.
+ */
+function resolveComparisonPair(
+	fileA?: string,
+	fileB?: string,
+): {beforePath: string; afterPath: string} {
+	if (fileA && fileB) {
+		return {
+			beforePath: resolveBenchmarkPath(fileA),
+			afterPath: resolveBenchmarkPath(fileB),
+		};
+	}
+
+	if (fileA) {
+		const explicitPath = resolveBenchmarkPath(fileA);
+		const latestPath = findLatestBenchmark();
+		if (!latestPath) {
+			throw new Error('No other benchmark runs found to compare against.');
+		}
+
+		// Compare resolved real paths, not raw strings — the same file can be
+		// reached through differently-formatted paths (relative vs. absolute,
+		// separator differences), and a false negative here would silently
+		// compare a run against itself instead of falling back correctly.
+		if (realpathSync(latestPath) === realpathSync(explicitPath)) {
+			const all = listBenchmarks();
+			if (all.length < 2) {
+				throw new Error(
+					'Need at least two saved benchmark runs to compare — only one exists.',
+				);
+			}
+			return orderByMtime(all[1].path, explicitPath);
+		}
+
+		return orderByMtime(latestPath, explicitPath);
+	}
+
+	const all = listBenchmarks();
+	if (all.length < 2) {
+		throw new Error(
+			`Need at least two saved benchmark runs to compare (found ${all.length}). Run \`nanotune benchmark\` again, or pass explicit files.`,
+		);
+	}
+	return orderByMtime(all[0].path, all[1].path);
+}
+
+export function BenchmarkCompareCommand({fileA, fileB}: Props) {
+	const {exit} = useApp();
+	const [status, setStatus] = useState<Status>('loading');
+	const [error, setError] = useState<string | null>(null);
+	const [comparison, setComparison] = useState<BenchmarkComparison | null>(
+		null,
+	);
+	const [savedPaths, setSavedPaths] = useState<{
+		json: string;
+		markdown: string;
+	} | null>(null);
+
+	useKeyInput((_input, key) => {
+		if (key.escape || key.return) {
+			exit();
+		}
+	});
+
+	useAutoExit(status === 'done' || status === 'error', status === 'error');
+
+	useEffect(() => {
+		try {
+			const {beforePath, afterPath} = resolveComparisonPair(fileA, fileB);
+			const before = loadBenchmark(beforePath);
+			const after = loadBenchmark(afterPath);
+
+			const result = compareBenchmarks(before, after);
+
+			const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+			const benchmarksDir = getBenchmarksDir();
+			if (!existsSync(benchmarksDir)) {
+				mkdirSync(benchmarksDir, {recursive: true});
+			}
+			const jsonPath = join(benchmarksDir, `compare-${timestamp}.json`);
+			const markdownPath = join(benchmarksDir, `compare-${timestamp}.md`);
+			writeFileSync(jsonPath, JSON.stringify(result, null, 2));
+			writeFileSync(markdownPath, generateComparisonMarkdown(result));
+
+			setComparison(result);
+			setSavedPaths({json: jsonPath, markdown: markdownPath});
+			setStatus('done');
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Comparison failed');
+			setStatus('error');
+		}
+	}, [fileA, fileB]);
+
+	if (status === 'error') {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Benchmark Compare" />
+				<StatusMessage variant="error">{error}</StatusMessage>
+				<Text> </Text>
+				<ExitHint>Press any key to exit</ExitHint>
+			</Box>
+		);
+	}
+
+	if (status === 'loading' || !comparison) {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Benchmark Compare" />
+			</Box>
+		);
+	}
+
+	const regressed = comparison.flips.filter(f => f.direction === 'regressed');
+	const fixed = comparison.flips.filter(f => f.direction === 'fixed');
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Header title="Benchmark Compare" />
+
+			<Text>
+				Before:{' '}
+				<Text color="cyan">{comparison.before.model.split('/').pop()}</Text>{' '}
+				<Text dimColor>
+					({comparison.before.passed}/{comparison.before.total},{' '}
+					{formatPercent(comparison.before.passRate)})
+				</Text>
+			</Text>
+			<Text>
+				After:{' '}
+				<Text color="cyan">{comparison.after.model.split('/').pop()}</Text>{' '}
+				<Text dimColor>
+					({comparison.after.passed}/{comparison.after.total},{' '}
+					{formatPercent(comparison.after.passRate)})
+				</Text>
+			</Text>
+			<Text> </Text>
+			<Text>
+				Overall Delta:{' '}
+				<Text
+					bold
+					color={
+						comparison.overallDelta > 0
+							? 'green'
+							: comparison.overallDelta < 0
+								? 'red'
+								: undefined
+					}
+				>
+					{formatDelta(comparison.overallDelta)}
+				</Text>
+			</Text>
+
+			<Text> </Text>
+			<Text bold>By Category:</Text>
+			<DataTable
+				headers={['Category', 'Before', 'After', 'Delta']}
+				columnWidths={[16, 14, 14, 8]}
+				rows={comparison.categories.map(cat => [
+					cat.category,
+					`${cat.before.passed}/${cat.before.total} (${formatPercent(cat.before.rate)})`,
+					`${cat.after.passed}/${cat.after.total} (${formatPercent(cat.after.rate)})`,
+					formatDelta(cat.delta),
+				])}
+			/>
+
+			<Text> </Text>
+			<Text bold>
+				Test Flips:{' '}
+				<Text dimColor>
+					({comparison.flips.length} total, {regressed.length} regressed,{' '}
+					{fixed.length} fixed)
+				</Text>
+			</Text>
+			{comparison.flips.length === 0 && (
+				<Text dimColor>No tests flipped between runs.</Text>
+			)}
+			{regressed.length > 0 && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text bold color="red">
+						Regressed (pass → fail):
+					</Text>
+					{regressed.map(flip => (
+						<Text key={flip.id}>
+							{'  '}[{flip.id}] {flip.category}: {flip.prompt}
+						</Text>
+					))}
+				</Box>
+			)}
+			{fixed.length > 0 && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text bold color="green">
+						Fixed (fail → pass):
+					</Text>
+					{fixed.map(flip => (
+						<Text key={flip.id}>
+							{'  '}[{flip.id}] {flip.category}: {flip.prompt}
+						</Text>
+					))}
+				</Box>
+			)}
+			{(comparison.onlyInBefore.length > 0 ||
+				comparison.onlyInAfter.length > 0) && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text bold dimColor>
+						Not present in both runs:
+					</Text>
+					{comparison.onlyInBefore.length > 0 && (
+						<Text dimColor>
+							{'  '}Only in before: {comparison.onlyInBefore.join(', ')}
+						</Text>
+					)}
+					{comparison.onlyInAfter.length > 0 && (
+						<Text dimColor>
+							{'  '}Only in after: {comparison.onlyInAfter.join(', ')}
+						</Text>
+					)}
+				</Box>
+			)}
+
+			{savedPaths && (
+				<>
+					<Text> </Text>
+					<Text dimColor>Saved: {savedPaths.markdown}</Text>
+				</>
+			)}
+
+			<Text> </Text>
+			<ExitHint>Press any key to exit</ExitHint>
+		</Box>
+	);
+}

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -193,6 +193,9 @@ export function StatusCommand() {
 							{latestBenchmark.summary.passed}/{latestBenchmark.summary.total} (
 							{Math.round(latestBenchmark.summary.passRate * 100)}%)
 						</Text>
+						{latestBenchmark.isBase && (
+							<Text dimColor> (base model, control)</Text>
+						)}
 						<Text dimColor>
 							{' '}
 							- {new Date(latestBenchmark.timestamp).toLocaleDateString()}

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -1,4 +1,4 @@
-import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import {existsSync, readdirSync, statSync} from 'node:fs';
 import {join} from 'node:path';
 import {StatusMessage} from '@inkjs/ui';
 import {Box, Text, useApp} from 'ink';
@@ -11,10 +11,11 @@ import {
 } from '../components/index.js';
 import {
 	configExists,
+	findLatestBenchmark,
 	getAdaptersDir,
-	getBenchmarksDir,
 	getDataDir,
 	getModelsDir,
+	loadBenchmark,
 	loadConfig,
 } from '../lib/config.js';
 import {countExamples} from '../lib/data.js';
@@ -71,7 +72,6 @@ export function StatusCommand() {
 	const dataDir = getDataDir();
 	const adaptersDir = getAdaptersDir();
 	const modelsDir = getModelsDir();
-	const benchmarksDir = getBenchmarksDir();
 
 	// Training data info
 	const exampleCount = countExamples();
@@ -106,22 +106,12 @@ export function StatusCommand() {
 
 	// Latest benchmark
 	let latestBenchmark: BenchmarkResult | null = null;
-	if (existsSync(benchmarksDir)) {
-		const benchmarkFiles = readdirSync(benchmarksDir)
-			.filter(f => f.endsWith('.json') && f.startsWith('benchmark'))
-			.sort()
-			.reverse();
-
-		if (benchmarkFiles.length > 0) {
-			try {
-				const content = readFileSync(
-					join(benchmarksDir, benchmarkFiles[0]),
-					'utf-8',
-				);
-				latestBenchmark = JSON.parse(content);
-			} catch {
-				// Ignore parse errors
-			}
+	const latestBenchmarkPath = findLatestBenchmark();
+	if (latestBenchmarkPath) {
+		try {
+			latestBenchmark = loadBenchmark(latestBenchmarkPath);
+		} catch {
+			// Ignore parse errors
 		}
 	}
 

--- a/src/lib/benchmark-compare.spec.ts
+++ b/src/lib/benchmark-compare.spec.ts
@@ -1,0 +1,204 @@
+import test from "ava";
+import type { BenchmarkResult, BenchmarkTestResult } from "../types/index.js";
+import { compareBenchmarks, generateComparisonMarkdown } from "./benchmark-compare.js";
+
+function testResult(
+  overrides: Partial<BenchmarkTestResult> & Pick<BenchmarkTestResult, "id" | "passed">,
+): BenchmarkTestResult {
+  return {
+    prompt: `prompt ${overrides.id}`,
+    expected: ["ok"],
+    actual: "ok",
+    category: "basic",
+    ...overrides,
+  };
+}
+
+function benchmarkResult(
+  overrides: Partial<BenchmarkResult> & { results: BenchmarkTestResult[] },
+): BenchmarkResult {
+  const results = overrides.results;
+  const passed = results.filter((r) => r.passed).length;
+  const total = results.length;
+
+  const categories: Record<string, { passed: number; total: number }> = {};
+  for (const r of results) {
+    categories[r.category] ??= { passed: 0, total: 0 };
+    categories[r.category].total += 1;
+    if (r.passed) categories[r.category].passed += 1;
+  }
+
+  return {
+    model: "test-model",
+    timestamp: new Date().toISOString(),
+    summary: { total, passed, failed: total - passed, passRate: total > 0 ? passed / total : 0 },
+    categories,
+    failures: [],
+    ...overrides,
+  };
+}
+
+// ── overall delta ────────────────────────────────────────────────────
+
+test("compareBenchmarks computes overall pass rate delta", (t) => {
+  const before = benchmarkResult({
+    model: "base",
+    results: [testResult({ id: 1, passed: true }), testResult({ id: 2, passed: false })],
+  });
+  const after = benchmarkResult({
+    model: "fine-tuned",
+    results: [testResult({ id: 1, passed: true }), testResult({ id: 2, passed: true })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.before.passRate, 0.5);
+  t.is(comparison.after.passRate, 1);
+  t.is(comparison.overallDelta, 0.5);
+});
+
+// ── per-category deltas ─────────────────────────────────────────────
+
+test("compareBenchmarks computes per-category deltas", (t) => {
+  const before = benchmarkResult({
+    results: [
+      testResult({ id: 1, passed: true, category: "math" }),
+      testResult({ id: 2, passed: false, category: "code" }),
+    ],
+  });
+  const after = benchmarkResult({
+    results: [
+      testResult({ id: 1, passed: true, category: "math" }),
+      testResult({ id: 2, passed: true, category: "code" }),
+    ],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  const math = comparison.categories.find((c) => c.category === "math");
+  const code = comparison.categories.find((c) => c.category === "code");
+
+  t.truthy(math);
+  t.is(math?.delta, 0);
+  t.truthy(code);
+  t.is(code?.delta, 1);
+});
+
+test("compareBenchmarks handles a category present in only one run", (t) => {
+  const before = benchmarkResult({
+    results: [testResult({ id: 1, passed: true, category: "math" })],
+  });
+  const after = benchmarkResult({
+    results: [
+      testResult({ id: 1, passed: true, category: "math" }),
+      testResult({ id: 2, passed: true, category: "reasoning" }),
+    ],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  const reasoning = comparison.categories.find((c) => c.category === "reasoning");
+
+  t.truthy(reasoning);
+  t.is(reasoning?.before.total, 0);
+  t.is(reasoning?.before.rate, 0);
+  t.is(reasoning?.after.rate, 1);
+});
+
+// ── flips ────────────────────────────────────────────────────────────
+
+test("compareBenchmarks reports a pass-to-fail flip as regressed", (t) => {
+  const before = benchmarkResult({ results: [testResult({ id: 5, passed: true })] });
+  const after = benchmarkResult({ results: [testResult({ id: 5, passed: false })] });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.flips.length, 1);
+  t.like(comparison.flips[0], {
+    id: 5,
+    direction: "regressed",
+    beforePassed: true,
+    afterPassed: false,
+  });
+});
+
+test("compareBenchmarks reports a fail-to-pass flip as fixed", (t) => {
+  const before = benchmarkResult({ results: [testResult({ id: 5, passed: false })] });
+  const after = benchmarkResult({ results: [testResult({ id: 5, passed: true })] });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.flips.length, 1);
+  t.like(comparison.flips[0], {
+    id: 5,
+    direction: "fixed",
+    beforePassed: false,
+    afterPassed: true,
+  });
+});
+
+test("compareBenchmarks does not report an unchanged test as a flip", (t) => {
+  const before = benchmarkResult({ results: [testResult({ id: 1, passed: true })] });
+  const after = benchmarkResult({ results: [testResult({ id: 1, passed: true })] });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.flips.length, 0);
+});
+
+test("compareBenchmarks surfaces flips even when the aggregate pass rate is unchanged", (t) => {
+  // Test 1 regresses, test 2 gets fixed — passRate stays flat at 50% in both
+  // runs, but two flips happened. This is the exact case the issue calls
+  // out: an aggregate score can hide regressions.
+  const before = benchmarkResult({
+    results: [testResult({ id: 1, passed: true }), testResult({ id: 2, passed: false })],
+  });
+  const after = benchmarkResult({
+    results: [testResult({ id: 1, passed: false }), testResult({ id: 2, passed: true })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.overallDelta, 0);
+  t.is(comparison.flips.length, 2);
+  t.true(comparison.flips.some((f) => f.id === 1 && f.direction === "regressed"));
+  t.true(comparison.flips.some((f) => f.id === 2 && f.direction === "fixed"));
+});
+
+// ── mismatched test id sets ─────────────────────────────────────────
+
+test("compareBenchmarks reports ids present in only one run without throwing", (t) => {
+  const before = benchmarkResult({
+    results: [testResult({ id: 1, passed: true }), testResult({ id: 2, passed: true })],
+  });
+  const after = benchmarkResult({
+    results: [testResult({ id: 2, passed: true }), testResult({ id: 3, passed: true })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.deepEqual(comparison.onlyInBefore, [1]);
+  t.deepEqual(comparison.onlyInAfter, [3]);
+  t.is(comparison.flips.length, 0);
+});
+
+// ── markdown report ──────────────────────────────────────────────────
+
+test("generateComparisonMarkdown includes overall delta, category table, and flips", (t) => {
+  const before = benchmarkResult({
+    model: "base-model",
+    results: [testResult({ id: 1, passed: true, category: "math" }), testResult({ id: 2, passed: true, category: "code" })],
+  });
+  const after = benchmarkResult({
+    model: "fine-tuned-model",
+    results: [testResult({ id: 1, passed: false, category: "math" }), testResult({ id: 2, passed: true, category: "code" })],
+  });
+
+  const markdown = generateComparisonMarkdown(compareBenchmarks(before, after));
+
+  t.true(markdown.includes("Overall Delta"));
+  t.true(markdown.includes("Per-Category"));
+  t.true(markdown.includes("math"));
+  t.true(markdown.includes("Regressed"));
+  t.true(markdown.includes("#1"));
+});
+
+test("generateComparisonMarkdown notes when no tests flipped", (t) => {
+  const before = benchmarkResult({ results: [testResult({ id: 1, passed: true })] });
+  const after = benchmarkResult({ results: [testResult({ id: 1, passed: true })] });
+
+  const markdown = generateComparisonMarkdown(compareBenchmarks(before, after));
+  t.true(markdown.includes("No tests flipped between runs."));
+});

--- a/src/lib/benchmark-compare.spec.ts
+++ b/src/lib/benchmark-compare.spec.ts
@@ -1,6 +1,10 @@
 import test from "ava";
 import type { BenchmarkResult, BenchmarkTestResult } from "../types/index.js";
-import { compareBenchmarks, generateComparisonMarkdown } from "./benchmark-compare.js";
+import {
+  compareBenchmarks,
+  deltaColor,
+  generateComparisonMarkdown,
+} from "./benchmark-compare.js";
 
 function testResult(
   overrides: Partial<BenchmarkTestResult> & Pick<BenchmarkTestResult, "id" | "passed">,
@@ -174,6 +178,63 @@ test("compareBenchmarks reports ids present in only one run without throwing", (
   t.is(comparison.flips.length, 0);
 });
 
+test("compareBenchmarks does not report a false flip when a reused id's prompt changed", (t) => {
+  // tests.json was edited between runs: id 5 used to be a different prompt.
+  // Reporting this as a "flip" would compare two unrelated tests.
+  const before = benchmarkResult({
+    results: [testResult({ id: 5, passed: true, prompt: "list all files" })],
+  });
+  const after = benchmarkResult({
+    results: [testResult({ id: 5, passed: false, prompt: "show current directory" })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.flips.length, 0);
+  t.deepEqual(comparison.onlyInBefore, [5]);
+  t.deepEqual(comparison.onlyInAfter, [5]);
+});
+
+test("compareBenchmarks still reports a real flip when the prompt is unchanged", (t) => {
+  const before = benchmarkResult({
+    results: [testResult({ id: 5, passed: true, prompt: "list all files" })],
+  });
+  const after = benchmarkResult({
+    results: [testResult({ id: 5, passed: false, prompt: "list all files" })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.is(comparison.flips.length, 1);
+  t.is(comparison.onlyInBefore.length, 0);
+  t.is(comparison.onlyInAfter.length, 0);
+});
+
+// ── isBase pass-through ──────────────────────────────────────────────
+
+test("compareBenchmarks carries isBase through to before/after", (t) => {
+  const before = benchmarkResult({
+    isBase: true,
+    results: [testResult({ id: 1, passed: true })],
+  });
+  const after = benchmarkResult({
+    isBase: false,
+    results: [testResult({ id: 1, passed: true })],
+  });
+
+  const comparison = compareBenchmarks(before, after);
+  t.true(comparison.before.isBase);
+  t.false(comparison.after.isBase);
+});
+
+// ── deltaColor ────────────────────────────────────────────────────────
+
+test("deltaColor matches the rounded sign, not the raw sign", (t) => {
+  t.is(deltaColor(0.004), undefined); // rounds to ±0%
+  t.is(deltaColor(-0.004), undefined); // rounds to ±0%
+  t.is(deltaColor(0.5), "green");
+  t.is(deltaColor(-0.5), "red");
+  t.is(deltaColor(0), undefined);
+});
+
 // ── markdown report ──────────────────────────────────────────────────
 
 test("generateComparisonMarkdown includes overall delta, category table, and flips", (t) => {
@@ -193,6 +254,21 @@ test("generateComparisonMarkdown includes overall delta, category table, and fli
   t.true(markdown.includes("math"));
   t.true(markdown.includes("Regressed"));
   t.true(markdown.includes("#1"));
+});
+
+test("generateComparisonMarkdown labels a base-model run", (t) => {
+  const before = benchmarkResult({
+    model: "base-model",
+    isBase: true,
+    results: [testResult({ id: 1, passed: true })],
+  });
+  const after = benchmarkResult({
+    model: "fine-tuned-model",
+    results: [testResult({ id: 1, passed: true })],
+  });
+
+  const markdown = generateComparisonMarkdown(compareBenchmarks(before, after));
+  t.true(markdown.includes("base-model (base, control)"));
 });
 
 test("generateComparisonMarkdown notes when no tests flipped", (t) => {

--- a/src/lib/benchmark-compare.ts
+++ b/src/lib/benchmark-compare.ts
@@ -23,6 +23,7 @@ export interface BenchmarkComparison {
 		passed: number;
 		total: number;
 		passRate: number;
+		isBase?: boolean;
 	};
 	after: {
 		model: string;
@@ -30,6 +31,7 @@ export interface BenchmarkComparison {
 		passed: number;
 		total: number;
 		passRate: number;
+		isBase?: boolean;
 	};
 	overallDelta: number;
 	categories: CategoryDelta[];
@@ -61,6 +63,7 @@ export function compareBenchmarks(
 			passed: before.summary.passed,
 			total: before.summary.total,
 			passRate: before.summary.passRate,
+			isBase: before.isBase,
 		},
 		after: {
 			model: after.model,
@@ -68,6 +71,7 @@ export function compareBenchmarks(
 			passed: after.summary.passed,
 			total: after.summary.total,
 			passRate: after.summary.passRate,
+			isBase: after.isBase,
 		},
 		overallDelta: after.summary.passRate - before.summary.passRate,
 		categories,
@@ -120,6 +124,15 @@ function diffTests(
 			onlyInBefore.push(id);
 			continue;
 		}
+		if (beforeTest.prompt !== afterTest.prompt) {
+			// Same id, different prompt — `tests.json` was edited between runs,
+			// so this isn't the same test. Reporting a pass/fail flip here would
+			// be comparing two unrelated tests; treat it like a dropped id on
+			// one side and an added id on the other instead.
+			onlyInBefore.push(id);
+			onlyInAfter.push(id);
+			continue;
+		}
 		if (beforeTest.passed !== afterTest.passed) {
 			flips.push({
 				id,
@@ -155,6 +168,16 @@ export function formatDelta(delta: number): string {
 	return pct > 0 ? `+${pct}%` : `${pct}%`;
 }
 
+/**
+ * Color for a delta value, using the same rounding as {@link formatDelta} so
+ * a delta that displays as "±0%" never renders green or red.
+ */
+export function deltaColor(delta: number): 'green' | 'red' | undefined {
+	const pct = Math.round(delta * 100);
+	if (pct === 0) return undefined;
+	return pct > 0 ? 'green' : 'red';
+}
+
 export function generateComparisonMarkdown(
 	comparison: BenchmarkComparison,
 ): string {
@@ -162,10 +185,10 @@ export function generateComparisonMarkdown(
 
 	lines.push('# Benchmark Comparison', '');
 	lines.push(
-		`**Before:** ${comparison.before.model} — ${comparison.before.passed}/${comparison.before.total} (${formatPercent(comparison.before.passRate)}) — ${new Date(comparison.before.timestamp).toLocaleString()}`,
+		`**Before:** ${comparison.before.model}${comparison.before.isBase ? ' (base, control)' : ''} — ${comparison.before.passed}/${comparison.before.total} (${formatPercent(comparison.before.passRate)}) — ${new Date(comparison.before.timestamp).toLocaleString()}`,
 	);
 	lines.push(
-		`**After:** ${comparison.after.model} — ${comparison.after.passed}/${comparison.after.total} (${formatPercent(comparison.after.passRate)}) — ${new Date(comparison.after.timestamp).toLocaleString()}`,
+		`**After:** ${comparison.after.model}${comparison.after.isBase ? ' (base, control)' : ''} — ${comparison.after.passed}/${comparison.after.total} (${formatPercent(comparison.after.passRate)}) — ${new Date(comparison.after.timestamp).toLocaleString()}`,
 	);
 	lines.push('');
 	lines.push(`**Overall Delta:** ${formatDelta(comparison.overallDelta)}`);

--- a/src/lib/benchmark-compare.ts
+++ b/src/lib/benchmark-compare.ts
@@ -1,0 +1,224 @@
+import type {BenchmarkResult} from '../types/index.js';
+
+export interface CategoryDelta {
+	category: string;
+	before: {passed: number; total: number; rate: number};
+	after: {passed: number; total: number; rate: number};
+	delta: number;
+}
+
+export interface TestFlip {
+	id: number;
+	prompt: string;
+	category: string;
+	beforePassed: boolean;
+	afterPassed: boolean;
+	direction: 'fixed' | 'regressed';
+}
+
+export interface BenchmarkComparison {
+	before: {
+		model: string;
+		timestamp: string;
+		passed: number;
+		total: number;
+		passRate: number;
+	};
+	after: {
+		model: string;
+		timestamp: string;
+		passed: number;
+		total: number;
+		passRate: number;
+	};
+	overallDelta: number;
+	categories: CategoryDelta[];
+	flips: TestFlip[];
+	onlyInBefore: number[];
+	onlyInAfter: number[];
+}
+
+/**
+ * Diff two saved benchmark runs. Tests are matched by id, so the comparison
+ * stays meaningful even if `before` and `after` ran against slightly
+ * different `tests.json` versions — ids present in only one run are reported
+ * via `onlyInBefore`/`onlyInAfter` rather than silently ignored.
+ */
+export function compareBenchmarks(
+	before: BenchmarkResult,
+	after: BenchmarkResult,
+): BenchmarkComparison {
+	const categories = diffCategories(before.categories, after.categories);
+	const {flips, onlyInBefore, onlyInAfter} = diffTests(
+		before.results,
+		after.results,
+	);
+
+	return {
+		before: {
+			model: before.model,
+			timestamp: before.timestamp,
+			passed: before.summary.passed,
+			total: before.summary.total,
+			passRate: before.summary.passRate,
+		},
+		after: {
+			model: after.model,
+			timestamp: after.timestamp,
+			passed: after.summary.passed,
+			total: after.summary.total,
+			passRate: after.summary.passRate,
+		},
+		overallDelta: after.summary.passRate - before.summary.passRate,
+		categories,
+		flips,
+		onlyInBefore,
+		onlyInAfter,
+	};
+}
+
+function diffCategories(
+	beforeCategories: Record<string, {passed: number; total: number}>,
+	afterCategories: Record<string, {passed: number; total: number}>,
+): CategoryDelta[] {
+	const names = new Set([
+		...Object.keys(beforeCategories),
+		...Object.keys(afterCategories),
+	]);
+
+	return [...names].sort().map(category => {
+		const beforeStats = beforeCategories[category] ?? {passed: 0, total: 0};
+		const afterStats = afterCategories[category] ?? {passed: 0, total: 0};
+		const beforeRate =
+			beforeStats.total > 0 ? beforeStats.passed / beforeStats.total : 0;
+		const afterRate =
+			afterStats.total > 0 ? afterStats.passed / afterStats.total : 0;
+
+		return {
+			category,
+			before: {...beforeStats, rate: beforeRate},
+			after: {...afterStats, rate: afterRate},
+			delta: afterRate - beforeRate,
+		};
+	});
+}
+
+function diffTests(
+	beforeResults: BenchmarkResult['results'],
+	afterResults: BenchmarkResult['results'],
+): Pick<BenchmarkComparison, 'flips' | 'onlyInBefore' | 'onlyInAfter'> {
+	const beforeById = new Map(beforeResults.map(r => [r.id, r]));
+	const afterById = new Map(afterResults.map(r => [r.id, r]));
+
+	const flips: TestFlip[] = [];
+	const onlyInBefore: number[] = [];
+	const onlyInAfter: number[] = [];
+
+	for (const [id, beforeTest] of beforeById) {
+		const afterTest = afterById.get(id);
+		if (!afterTest) {
+			onlyInBefore.push(id);
+			continue;
+		}
+		if (beforeTest.passed !== afterTest.passed) {
+			flips.push({
+				id,
+				prompt: afterTest.prompt,
+				category: afterTest.category,
+				beforePassed: beforeTest.passed,
+				afterPassed: afterTest.passed,
+				direction: afterTest.passed ? 'fixed' : 'regressed',
+			});
+		}
+	}
+
+	for (const id of afterById.keys()) {
+		if (!beforeById.has(id)) {
+			onlyInAfter.push(id);
+		}
+	}
+
+	flips.sort((a, b) => a.id - b.id);
+	onlyInBefore.sort((a, b) => a - b);
+	onlyInAfter.sort((a, b) => a - b);
+
+	return {flips, onlyInBefore, onlyInAfter};
+}
+
+export function formatPercent(rate: number): string {
+	return `${Math.round(rate * 100)}%`;
+}
+
+export function formatDelta(delta: number): string {
+	const pct = Math.round(delta * 100);
+	if (pct === 0) return '±0%';
+	return pct > 0 ? `+${pct}%` : `${pct}%`;
+}
+
+export function generateComparisonMarkdown(
+	comparison: BenchmarkComparison,
+): string {
+	const lines: string[] = [];
+
+	lines.push('# Benchmark Comparison', '');
+	lines.push(
+		`**Before:** ${comparison.before.model} — ${comparison.before.passed}/${comparison.before.total} (${formatPercent(comparison.before.passRate)}) — ${new Date(comparison.before.timestamp).toLocaleString()}`,
+	);
+	lines.push(
+		`**After:** ${comparison.after.model} — ${comparison.after.passed}/${comparison.after.total} (${formatPercent(comparison.after.passRate)}) — ${new Date(comparison.after.timestamp).toLocaleString()}`,
+	);
+	lines.push('');
+	lines.push(`**Overall Delta:** ${formatDelta(comparison.overallDelta)}`);
+	lines.push('');
+
+	lines.push('## Per-Category', '');
+	lines.push('| Category | Before | After | Delta |');
+	lines.push('| --- | --- | --- | --- |');
+	for (const cat of comparison.categories) {
+		lines.push(
+			`| ${cat.category} | ${cat.before.passed}/${cat.before.total} (${formatPercent(cat.before.rate)}) | ${cat.after.passed}/${cat.after.total} (${formatPercent(cat.after.rate)}) | ${formatDelta(cat.delta)} |`,
+		);
+	}
+	lines.push('');
+
+	lines.push('## Test Flips', '');
+	if (comparison.flips.length === 0) {
+		lines.push('No tests flipped between runs.');
+	} else {
+		const regressed = comparison.flips.filter(f => f.direction === 'regressed');
+		const fixed = comparison.flips.filter(f => f.direction === 'fixed');
+
+		if (regressed.length > 0) {
+			lines.push(`### Regressed (pass → fail) — ${regressed.length}`, '');
+			for (const flip of regressed) {
+				lines.push(`- **#${flip.id}** [${flip.category}] ${flip.prompt}`);
+			}
+			lines.push('');
+		}
+
+		if (fixed.length > 0) {
+			lines.push(`### Fixed (fail → pass) — ${fixed.length}`, '');
+			for (const flip of fixed) {
+				lines.push(`- **#${flip.id}** [${flip.category}] ${flip.prompt}`);
+			}
+			lines.push('');
+		}
+	}
+
+	if (comparison.onlyInBefore.length > 0 || comparison.onlyInAfter.length > 0) {
+		lines.push('## Tests Not Present In Both Runs', '');
+		if (comparison.onlyInBefore.length > 0) {
+			lines.push(
+				`- Only in before run: ${comparison.onlyInBefore.map(id => `#${id}`).join(', ')}`,
+			);
+		}
+		if (comparison.onlyInAfter.length > 0) {
+			lines.push(
+				`- Only in after run: ${comparison.onlyInAfter.map(id => `#${id}`).join(', ')}`,
+			);
+		}
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -10,6 +10,8 @@ import { ConfigSchema } from "../types/index.js";
 import {
   createDefaultConfig,
   findLatestGGUF,
+  listBenchmarks,
+  resolveBenchmarkPath,
   findUnknownConfigKeys,
   loadConfig,
   resolveContextMessage,
@@ -307,6 +309,122 @@ test.serial("findLatestGGUF ignores non-.gguf siblings", (t) => {
     t.is(findLatestGGUF(), ggufFile);
   } finally {
     teardownGGUFTest();
+  }
+});
+
+// ── listBenchmarks / resolveBenchmarkPath ────────────────────────────
+
+const BENCH_TEST_DIR = join(ORIG_CWD, ".test-config-benchmarks");
+const BENCH_DIR = join(BENCH_TEST_DIR, ".nanotune", "benchmarks");
+
+function setupBenchTest() {
+  rmSync(BENCH_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BENCH_TEST_DIR, { recursive: true });
+  process.chdir(BENCH_TEST_DIR);
+}
+
+function teardownBenchTest() {
+  process.chdir(ORIG_CWD);
+  rmSync(BENCH_TEST_DIR, { recursive: true, force: true });
+}
+
+test.serial("listBenchmarks returns an empty array when the benchmarks directory is missing", (t) => {
+  setupBenchTest();
+  try {
+    t.deepEqual(listBenchmarks(), []);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("listBenchmarks sorts by mtime, not filename, and ignores compare-* files", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    // Deliberately give the lexicographically-later filename the older mtime,
+    // so a naive filename sort would get this backwards.
+    const older = join(BENCH_DIR, "benchmark-z-older.json");
+    const newer = join(BENCH_DIR, "benchmark-a-newer.json");
+    const compareFile = join(BENCH_DIR, "compare-should-be-excluded.json");
+    writeFileSync(older, "{}");
+    writeFileSync(newer, "{}");
+    writeFileSync(compareFile, "{}");
+
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(older, past, past);
+
+    const listed = listBenchmarks();
+    t.is(listed.length, 2);
+    t.is(listed[0].filename, "benchmark-a-newer.json");
+    t.is(listed[1].filename, "benchmark-z-older.json");
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("resolveBenchmarkPath resolves a literal path", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const literal = join(BENCH_DIR, "benchmark-literal.json");
+    writeFileSync(literal, "{}");
+    t.is(resolveBenchmarkPath(literal), literal);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("resolveBenchmarkPath resolves a bare filename under the benchmarks dir", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const target = join(BENCH_DIR, "benchmark-bare.json");
+    writeFileSync(target, "{}");
+    t.is(resolveBenchmarkPath("benchmark-bare.json"), target);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("resolveBenchmarkPath appends .json when missing", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const target = join(BENCH_DIR, "benchmark-noext.json");
+    writeFileSync(target, "{}");
+    t.is(resolveBenchmarkPath("benchmark-noext"), target);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("resolveBenchmarkPath resolves a bare timestamp via the benchmark- prefix", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const target = join(BENCH_DIR, "benchmark-2026-01-01T00-00-00-000Z.json");
+    writeFileSync(target, "{}");
+    t.is(
+      resolveBenchmarkPath("2026-01-01T00-00-00-000Z"),
+      target,
+    );
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("resolveBenchmarkPath throws with the list of available runs when nothing matches", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const existing = join(BENCH_DIR, "benchmark-exists.json");
+    writeFileSync(existing, "{}");
+
+    const err = t.throws(() => resolveBenchmarkPath("does-not-exist"));
+    t.truthy(err);
+    t.true(err?.message.includes("benchmark-exists.json"));
+  } finally {
+    teardownBenchTest();
   }
 });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,7 +8,12 @@ import {
 } from 'node:fs';
 import {join} from 'node:path';
 import {z} from 'zod';
-import {type ChatMessage, type Config, ConfigSchema} from '../types/index.js';
+import {
+	type BenchmarkResult,
+	type ChatMessage,
+	type Config,
+	ConfigSchema,
+} from '../types/index.js';
 
 const CONFIG_DIR = '.nanotune';
 const CONFIG_FILE = 'config.json';
@@ -217,6 +222,85 @@ export function findLatestGGUF(): string | null {
 		.map(f => ({name: f, path: join(modelsDir, f)}))
 		.sort((a, b) => statSync(b.path).mtimeMs - statSync(a.path).mtimeMs);
 	return sorted[0].path;
+}
+
+export interface BenchmarkFileInfo {
+	path: string;
+	filename: string;
+	mtime: Date;
+}
+
+/**
+ * List saved benchmark run files (`benchmark-*.json`) in the project's
+ * benchmarks directory, newest first by mtime. Sorting by mtime (rather than
+ * filename) keeps this correct even if benchmark filenames stop sharing a
+ * single timestamp shape.
+ */
+export function listBenchmarks(): BenchmarkFileInfo[] {
+	const benchmarksDir = getBenchmarksDir();
+	if (!existsSync(benchmarksDir)) {
+		return [];
+	}
+	return readdirSync(benchmarksDir)
+		.filter(f => f.endsWith('.json') && f.startsWith('benchmark'))
+		.map(filename => {
+			const path = join(benchmarksDir, filename);
+			return {path, filename, mtime: statSync(path).mtime};
+		})
+		.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+}
+
+/**
+ * Find the most recently modified saved benchmark run. Returns `null` if the
+ * benchmarks directory is missing or contains no runs.
+ */
+export function findLatestBenchmark(): string | null {
+	const benchmarks = listBenchmarks();
+	return benchmarks.length > 0 ? benchmarks[0].path : null;
+}
+
+/**
+ * Load and parse a saved benchmark run. Accepts a literal path or a value
+ * resolved via {@link resolveBenchmarkPath}.
+ */
+export function loadBenchmark(pathOrName: string): BenchmarkResult {
+	const path = resolveBenchmarkPath(pathOrName);
+	const content = readFileSync(path, 'utf-8');
+	return JSON.parse(content) as BenchmarkResult;
+}
+
+/**
+ * Resolve a user-supplied benchmark reference to a file path. Tries, in
+ * order: the literal path (relative to cwd or absolute), the bare filename
+ * under the benchmarks directory, that filename with `.json` appended, and
+ * finally `benchmark-<input>.json` (so a copy-pasted timestamp works).
+ * Throws with the list of available runs if nothing matches.
+ */
+export function resolveBenchmarkPath(input: string): string {
+	const benchmarksDir = getBenchmarksDir();
+	const candidates = [
+		input,
+		join(benchmarksDir, input),
+		join(benchmarksDir, `${input}.json`),
+	];
+	if (!input.startsWith('benchmark')) {
+		candidates.push(join(benchmarksDir, `benchmark-${input}.json`));
+	}
+
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	const available = listBenchmarks()
+		.map(b => b.filename)
+		.join(', ');
+	throw new Error(
+		`Could not find a benchmark run matching "${input}".${
+			available ? ` Available runs: ${available}` : ' No benchmark runs found.'
+		}`,
+	);
 }
 
 export function resolveContextMessage(config: Config): ChatMessage {

--- a/src/lib/mlx.ts
+++ b/src/lib/mlx.ts
@@ -150,7 +150,7 @@ if result["error"]:
     print(json.dumps({"status":"error","error":result["error"]}), flush=True)
     sys.exit(1)
 else:
-    print(json.dumps({"status":"done","percent":100}), flush=True)
+    print(json.dumps({"status":"done","percent":100,"path":result["path"]}), flush=True)
 `.trim();
 
 export interface DownloadStatus {
@@ -160,6 +160,8 @@ export interface DownloadStatus {
 	downloaded?: number;
 	percent?: number;
 	error?: string;
+	/** Resolved local snapshot directory, present on the final 'done' event. */
+	path?: string;
 }
 
 export async function* ensureModelDownloaded(
@@ -218,7 +220,7 @@ export async function* ensureModelDownloaded(
 									: undefined,
 						};
 					} else if (msg.status === 'done') {
-						yield {type: 'download', percent: 100};
+						yield {type: 'download', percent: 100, path: msg.path};
 					} else if (msg.status === 'error') {
 						downloadError = msg.error || 'Model download failed';
 					}

--- a/src/lib/model-cache.spec.ts
+++ b/src/lib/model-cache.spec.ts
@@ -1,0 +1,30 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import test from "ava";
+import { getBaseModelCachePath, sanitizeModelId } from "./model-cache.js";
+
+test("sanitizeModelId replaces slashes with double dashes", (t) => {
+  t.is(sanitizeModelId("Qwen/Qwen2.5-Coder-1.5B-Instruct"), "Qwen--Qwen2.5-Coder-1.5B-Instruct");
+});
+
+test("sanitizeModelId leaves ids without slashes unchanged", (t) => {
+  t.is(sanitizeModelId("gpt2"), "gpt2");
+});
+
+test("sanitizeModelId replaces every slash in a nested id", (t) => {
+  t.is(sanitizeModelId("org/team/model"), "org--team--model");
+});
+
+test("getBaseModelCachePath composes a deterministic path from model id and quantization", (t) => {
+  const path = getBaseModelCachePath("Qwen/Qwen2.5-Coder-1.5B-Instruct", "q4_k_m");
+  t.is(
+    path,
+    join(homedir(), ".nanotune", "models", "base-cache", "Qwen--Qwen2.5-Coder-1.5B-Instruct-q4_k_m.gguf"),
+  );
+});
+
+test("getBaseModelCachePath varies with quantization", (t) => {
+  const q4 = getBaseModelCachePath("org/model", "q4_k_m");
+  const f16 = getBaseModelCachePath("org/model", "f16");
+  t.not(q4, f16);
+});

--- a/src/lib/model-cache.spec.ts
+++ b/src/lib/model-cache.spec.ts
@@ -1,7 +1,17 @@
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import test from "ava";
-import { getBaseModelCachePath, sanitizeModelId } from "./model-cache.js";
+import {
+  getBaseModelCachePath,
+  sanitizeModelId,
+  sweepStaleCacheArtifacts,
+} from "./model-cache.js";
 
 test("sanitizeModelId replaces slashes with double dashes", (t) => {
   t.is(sanitizeModelId("Qwen/Qwen2.5-Coder-1.5B-Instruct"), "Qwen--Qwen2.5-Coder-1.5B-Instruct");
@@ -27,4 +37,34 @@ test("getBaseModelCachePath varies with quantization", (t) => {
   const q4 = getBaseModelCachePath("org/model", "q4_k_m");
   const f16 = getBaseModelCachePath("org/model", "f16");
   t.not(q4, f16);
+});
+
+// ── sweepStaleCacheArtifacts ─────────────────────────────────────────
+
+const SWEEP_TEST_DIR = join(process.cwd(), ".test-model-cache-sweep");
+
+test.serial("sweepStaleCacheArtifacts is a no-op when the directory doesn't exist", (t) => {
+  rmSync(SWEEP_TEST_DIR, { recursive: true, force: true });
+  t.notThrows(() => sweepStaleCacheArtifacts(SWEEP_TEST_DIR));
+});
+
+test.serial("sweepStaleCacheArtifacts removes stale .tmp-<pid>.gguf and -f16.gguf leftovers", (t) => {
+  rmSync(SWEEP_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(SWEEP_TEST_DIR, { recursive: true });
+  try {
+    const staleTemp = join(SWEEP_TEST_DIR, "model-q4_k_m.tmp-1234.gguf");
+    const staleF16 = join(SWEEP_TEST_DIR, "model-q4_k_m.tmp-1234-f16.gguf");
+    const validCache = join(SWEEP_TEST_DIR, "model-q4_k_m.gguf");
+    writeFileSync(staleTemp, "stub");
+    writeFileSync(staleF16, "stub");
+    writeFileSync(validCache, "stub");
+
+    sweepStaleCacheArtifacts(SWEEP_TEST_DIR);
+
+    t.false(existsSync(staleTemp));
+    t.false(existsSync(staleF16));
+    t.true(existsSync(validCache));
+  } finally {
+    rmSync(SWEEP_TEST_DIR, { recursive: true, force: true });
+  }
 });

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -1,0 +1,32 @@
+import {homedir} from 'node:os';
+import {join} from 'node:path';
+import type {QuantizationType} from '../types/index.js';
+
+/**
+ * Mirror HuggingFace's own cache-directory convention (`models--org--name`)
+ * so cached base-model GGUFs are recognizable next to the HF snapshot cache
+ * they were built from.
+ */
+export function sanitizeModelId(modelId: string): string {
+	return modelId.replace(/\//g, '--');
+}
+
+/**
+ * Path to the cached quantized GGUF for a base model, keyed by model id and
+ * quantization. Lives under the home directory (like `~/.nanotune/llama.cpp`)
+ * rather than the project's `.nanotune/models/`, since the expensive
+ * download+convert+quantize work is reusable across every project that
+ * fine-tunes from the same base model.
+ */
+export function getBaseModelCachePath(
+	baseModel: string,
+	quantization: QuantizationType,
+): string {
+	return join(
+		homedir(),
+		'.nanotune',
+		'models',
+		'base-cache',
+		`${sanitizeModelId(baseModel)}-${quantization}.gguf`,
+	);
+}

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -1,3 +1,4 @@
+import {existsSync, readdirSync, rmSync} from 'node:fs';
 import {homedir} from 'node:os';
 import {join} from 'node:path';
 import type {QuantizationType} from '../types/index.js';
@@ -29,4 +30,22 @@ export function getBaseModelCachePath(
 		'base-cache',
 		`${sanitizeModelId(baseModel)}-${quantization}.gguf`,
 	);
+}
+
+/**
+ * Remove leftover `.tmp-<pid>.gguf` cache files (and their `-f16.gguf`
+ * conversion intermediates, which share the same `.tmp-<pid>` stem) from a
+ * previous export that was interrupted before its `finally` cleanup could
+ * run — e.g. a killed process on SIGINT. Safe to call unconditionally before
+ * starting a new export; a no-op if the directory doesn't exist yet.
+ */
+export function sweepStaleCacheArtifacts(cacheDir: string): void {
+	if (!existsSync(cacheDir)) {
+		return;
+	}
+	for (const name of readdirSync(cacheDir)) {
+		if (name.includes('.tmp-') && name.endsWith('.gguf')) {
+			rmSync(join(cacheDir, name), {force: true});
+		}
+	}
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,8 @@ export interface DownloadProgress {
 	fileName?: string;
 	percent?: number;
 	sizeInfo?: string;
+	/** Resolved local snapshot directory, present on the final 100%-done event. */
+	path?: string;
 }
 
 export interface TrainingExample {
@@ -154,6 +156,8 @@ export interface BenchmarkTestResult {
 export interface BenchmarkResult {
 	model: string;
 	timestamp: string;
+	/** True when this run benchmarked the base (pre-fine-tuning) model as a control. */
+	isBase?: boolean;
 	summary: {
 		total: number;
 		passed: number;


### PR DESCRIPTION
## Description

 lets users see whether fine-tuning actually helped, instead of only ever seeing a fine-tuned model's score in isolation.

Two additive pieces:
- **`nanotune benchmark compare [fileA] [fileB]`** — diffs two saved benchmark runs from `.nanotune/benchmarks/`. Shows overall pass-rate delta, per-category deltas, and  the part that matters most which individual tests flipped pass→fail or fail→pass, since that can hide inside a flat aggregate score. Works with 0 args (latest two runs), 1 arg (that run vs. latest), or 2 args (explicit before/after). Saves a markdown report alongside the JSON.
- **`nanotune benchmark --base`** — benchmarks the base (pre-fine-tuning) model as a control, so you get a before/after number without manually re-exporting or swapping GGUF files. The quantized base model is cached under `~/.nanotune/models/base-cache/` (keyed by model id + quantization) so repeat runs don't re-download or re-quantize.

## Fixes #58 
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New tests added for new functionality — 15 new unit tests (`benchmark-compare.spec.ts`, `model-cache.spec.ts`), covering the delta/flip math including the exact "flat pass rate hides real flips" case the issue calls out.
- [ ] All existing tests pass — with a caveat worth flagging: this was developed on **Windows**, where `pnpm test:all` has pre-existing, unrelated
failures I confirmed also occur on a clean checkout of `main): 14 `ava` hooks / 2 tests fail due to Windows file-locking(`EPERM` on cleanup) and POSIX permission bits (`chmod 0600`) not mapping onto NTFS, and the formatter step flags ~37 false positives from
`core.autocrlf` converting the whole repo to CRLF locally. `rule-level, not the CRLF noise), `knip`, and `pnpm build` are all clean. `semgrep` (`test:security`) isn't installed in this environment and wasn't run. All of this should behave normally on macOS/Linux CI.

### Manual Testing

- [x] New tests added for new functionality — 15 new unit tests (`benchmark-compare.spec.ts`, `model-cache.spec.ts`), covering the delta/flip math including the exact "flat pass rate hides real flips" case the issue calls out.
- [ ] All existing tests pass — with a caveat worth flagging: this was developed on **Windows**, where `pnpm test:all` has pre-existing, unrelated
failures I confirmed also occur on a clean checkout of `main): 14 `ava` hooks / 2 tests fail due to Windows file-locking(`EPERM` on cleanup) and POSIX permission bits (`chmod 0600`) not mapping onto NTFS, and the formatter step flags ~37 false positives from
`core.autocrlf` converting the whole repo to CRLF locally. `rule-level, not the CRLF noise), `knip`, and `pnpm build` are all clean. `semgrep` (`test:security`) isn't installed in this environment and wasn't run. All of this should behave normally on macOS/Linux CI.

### Manual Testing

- [ ] Tested `nanotune init`
- [ ] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [x] Tested `nanotune benchmark` — only the new `compare` subcommand, not the base `benchmark`/`--base` execution path itself. `compare` was run for real against fixture data covering: 0/1/2-arg forms, bare timestamps, literal file paths, the "fewer than two runs" error path, and a project
directory with no `.nanotune/` folder at all (caught a real s`, which was refactored as part of this change, was alsomanually re-verified to still show the correct latest benchmark.

**`--base` has not been run at all.** It's gated by `assertSupportedPlatform()` (macOS + Apple Silicon only, for MLX and the llama.cpp toolchain), so
it can't execute on Windows. It type-checks, lints, and reusand's`exportModel`/`checkLlamaCppInstalled`/`installLlamaCpp` pipeline unchanged  but the download → cache → benchmark flow itself has never actually run. **This needs verification by someone on Apple Silicon before merge.** Happy to provide a step-by-step verification checklist for whoever picks that
up.

A self-review pass (`/code-review`) also caught and fixed 2 real bugs before this was pushed: `compare` crashing when `.nanotune/benchmarks/` doesn't exist yet, and the `--base` cache being written non-atomically (an interrupted run could leave a corrupt GGUF that gets silently reused on every
future run  now written to a temp file and renamed into pla

## Checklist

- [ ] Code follows project style guidelines (`pnpm format`) ormat` locally would rewrite every file's line endingsrepo-wide due to the Windows CRLF checkout issue above, so I deliberately scoped formatting checks to only the files this PR touches instead (`biome
check`, clean). Worth a `pnpm format` pass by someone on mac repo is untouched.
- [x] Self-review completed
- [ ] Documentation updated — none needed; the new flag/subcommand are self-documented via `--help` text (Commander option descriptions).
- [x] No breaking changes — everything here is additive: a nd two new optional fields (`BenchmarkResult.isBase`,`DownloadProgress.path`).