### PR TITLE
fix: report accurate export progress during quantization

### DIFF
--- a/src/lib/llama-cpp.spec.ts
+++ b/src/lib/llama-cpp.spec.ts
@@ -5,8 +5,11 @@ import type {
 	InferenceResult,
 } from "./llama-cpp.js";
 import {
+	exportModel,
 	parseChatCompletionResponse,
 	parseLlamaCppStderr,
+	quantize,
+	scaleProgress,
 } from "./llama-cpp.js";
 
 test("InferenceOptions structure accepts all valid options", (t) => {
@@ -318,4 +321,38 @@ test("parseChatCompletionResponse returns InferenceResult-shaped value", (t) => 
 	});
 	// Type-asserts at compile time; smoke check at runtime.
 	t.is(typeof result.text, "string");
+});
+
+test("scaleProgress maps a sub-step onto its slice of the export", (t) => {
+	t.is(scaleProgress(0, 50, 0), 0);
+	t.is(scaleProgress(0, 50, 100), 50);
+	t.is(scaleProgress(50, 100, 0), 50);
+	t.is(scaleProgress(50, 100, 100), 100);
+});
+
+test("scaleProgress stays mid-slice while a sub-step is still running", (t) => {
+	// A sub-step that has not reported progress yet must never read as done.
+	t.is(scaleProgress(0, 50, undefined), 25);
+	t.is(scaleProgress(50, 100, undefined), 75);
+});
+
+test("quantize reports no progress on its kickoff event", async (t) => {
+	// Only the first yield is pulled, so llama-quantize is never spawned.
+	const first = await quantize("in.gguf", "out.gguf", "q4_k_m").next();
+
+	t.is(first.value?.step, "Quantizing to q4_k_m...");
+	t.is(first.value?.progress, undefined);
+});
+
+test("exportModel does not jump to 100% before quantization finishes", async (t) => {
+	// Regression: the quantize kickoff event used to be re-yielded as
+	// progress: 100 while a multi-GB model was still being written.
+	const gen = exportModel("fused", "model.gguf", "q4_k_m");
+	const start = await gen.next();
+	const converting = await gen.next();
+	await gen.return(undefined);
+
+	t.is(start.value?.progress, 0);
+	t.is(converting.value?.progress, 25);
+	t.is(scaleProgress(50, 100, undefined), 75);
 });

--- a/src/lib/llama-cpp.ts
+++ b/src/lib/llama-cpp.ts
@@ -242,6 +242,19 @@ export async function* quantize(
 	yield {step: 'Quantization complete!', progress: 100};
 }
 
+/**
+ * Maps a sub-step's own 0-100 progress onto its slice of the overall export.
+ * Sub-steps that report no progress yet are treated as mid-slice, so the bar
+ * shows work in flight instead of a premature 100%.
+ */
+export function scaleProgress(
+	start: number,
+	end: number,
+	progress?: number,
+): number {
+	return start + ((progress ?? 50) / 100) * (end - start);
+}
+
 export async function* exportModel(
 	fusedModelPath: string,
 	outputPath: string,
@@ -253,8 +266,11 @@ export async function* exportModel(
 	yield {step: 'Step 1/2: Converting to GGUF...', progress: 0};
 
 	try {
-		for await (const progress of convertToGGUF(fusedModelPath, f16Path)) {
-			yield {step: progress.step, progress: 25};
+		for await (const update of convertToGGUF(fusedModelPath, f16Path)) {
+			yield {
+				step: update.step,
+				progress: scaleProgress(0, 50, update.progress),
+			};
 		}
 
 		// Step 2: Quantize if needed
@@ -268,8 +284,11 @@ export async function* exportModel(
 
 		yield {step: `Step 2/2: Quantizing to ${quantization}...`, progress: 50};
 
-		for await (const progress of quantize(f16Path, outputPath, quantization)) {
-			yield {step: progress.step, progress: 100};
+		for await (const update of quantize(f16Path, outputPath, quantization)) {
+			yield {
+				step: update.step,
+				progress: scaleProgress(50, 100, update.progress),
+			};
 		}
 
 		yield {step: 'Export complete!', progress: 100};


### PR DESCRIPTION
Fixes #83

## Description

`exportModel` discarded the progress reported by its sub-generators and hardcoded a value
for every event it re-yielded — `25` for convert, `100` for quantize. Because `quantize`
yields its `Quantizing to <type>...` kickoff event *before* spawning `llama-quantize`,
consumers saw `progress: 100` the instant quantization started.

A `scaleProgress(start, end, progress)` helper now maps each sub-step's own 0-100 progress
onto its slice of the export. Sub-steps that have not reported progress yet read as
mid-slice, so the bar shows work in flight rather than a premature 100%.

No change was needed in `src/commands/export.tsx` — its existing step-string mapping
already produced these same values, so the TUI is unchanged while the generator's contract
is now correct for any consumer.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass 
- [x] New tests added for new functionality

Run on the branch, in a clean worktree:

### Manual Testing

- [ ] Tested `nanotune init` 
- [x] Tested `nanotune data`
- [ ] Tested `nanotune train`
- [x] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes 