### PR TITLE
feat: wire up data edit, validate --fix/--rewrite-context, and data e…

### DIFF
--- a/docs/commands/data.md
+++ b/docs/commands/data.md
@@ -1,12 +1,12 @@
 ---
 title: "nanotune data"
-description: "Add, import, list, and validate training data"
+description: "Add, edit, import, export, list, and validate training data"
 sidebar_order: 2
 ---
 
 # nanotune data
 
-Manage your training data. This command group includes subcommands for adding, importing, listing, and validating examples.
+Manage your training data. This command group includes subcommands for adding, editing, importing, exporting, listing, and validating examples.
 
 ## nanotune data add
 
@@ -58,13 +58,52 @@ nanotune data import examples.jsonl --yes
 
 See the [Training Data](../guides/training-data.md) guide for format details and examples.
 
+## nanotune data export
+
+```bash
+nanotune data export <file>
+```
+
+Export training data to a file. Uses the same formats as `data import`, selected by the output file's extension:
+
+| Format | Extension | Description |
+|--------|-----------|-------------|
+| JSONL | `.jsonl` | Chat format with messages array (recommended) |
+| CSV | `.csv` | Simple input/output columns |
+| JSON | `.json` | Array of examples |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-y, --yes` | Skip the overwrite confirmation prompt |
+
+JSONL and JSON exports preserve every example exactly, including multi-turn conversations and per-example context messages — feeding the output back into `data import` reproduces the original data. **CSV has no way to represent multi-turn examples**, so any example with more than one turn is skipped (not truncated) during a CSV export, and reported in the summary.
+
+If the target file already exists, you're asked to confirm before it's overwritten. Pass `--yes` to skip the prompt — this is also what lets `data export` run in a script or CI job.
+
+```bash
+nanotune data export backup.jsonl --yes
+```
+
 ## nanotune data list
 
 ```bash
 nanotune data list
 ```
 
-View and manage your training data with pagination and delete. Shows a **Turns** column indicating how many user/assistant exchanges each example contains. Press **Enter** on any row to expand/collapse the full conversation.
+View and manage your training data with pagination, editing, and delete. Shows a **Turns** column indicating how many user/assistant exchanges each example contains.
+
+| Key | Action |
+|-----|--------|
+| Up/Down | Navigate rows |
+| Left/Right | Change page |
+| Enter | Expand/collapse the full conversation |
+| e | Edit the selected example |
+| d | Delete the selected example |
+| q | Quit |
+
+Editing reuses the same input flow as `data add`, but only covers the example's **first** user/assistant turn — any additional turns and the example's context message are preserved unchanged. Press **Tab** to switch between the input and output fields, **Enter** to submit a field, and **Esc** to cancel without saving.
 
 ## nanotune data validate
 
@@ -80,6 +119,19 @@ Validate your training data before training. Checks for:
 - Context message consistency
 - Minimum example count
 - Consecutive same-role messages (broken turn alternation)
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--fix` | Remove exact-duplicate examples (identical messages, not just matching input text) |
+| `--rewrite-context` | Rewrite each example's context message to match the current config |
+
+`--fix` is intentionally stricter than the "duplicate user inputs" warning above: the warning flags examples that merely share the same input text (worth a human look, since the outputs or context could differ on purpose), while `--fix` only ever removes examples whose entire message list is identical — the only case where deleting one is provably safe. `--rewrite-context` only touches examples that already have a context/system message; it never inserts one where an example starts directly with a user message. Both flags report exactly how many examples they changed, and can be combined:
+
+```bash
+nanotune data validate --fix --rewrite-context
+```
 
 ## See Also
 

--- a/docs/guides/training-data.md
+++ b/docs/guides/training-data.md
@@ -82,13 +82,23 @@ nanotune data import examples.jsonl
 
 The importer auto-detects format based on file extension and content. Multi-turn examples in JSONL and JSON files are preserved with all their turns intact.
 
-## Viewing Data
+## Exporting Data
+
+```bash
+nanotune data export backup.jsonl
+```
+
+Writes your training data back out in the same formats `data import` accepts (JSONL, CSV, or JSON — selected by the output file's extension). JSONL and JSON exports round-trip exactly, including multi-turn examples and per-example context messages. **CSV can only represent a single input/output pair per example**, so multi-turn examples are skipped (not truncated) during a CSV export and called out in the summary — export to JSONL or JSON instead if you need every example preserved.
+
+## Viewing and Editing Data
 
 ```bash
 nanotune data list
 ```
 
-The data list shows a **Turns** column indicating how many user/assistant exchanges each example contains. Press **Enter** on any row to expand/collapse the full conversation.
+The data list shows a **Turns** column indicating how many user/assistant exchanges each example contains. Press **Enter** on any row to expand/collapse the full conversation, **e** to edit it, or **d** to delete it.
+
+Editing reuses the `data add` input flow, but only the example's first user/assistant turn is editable — additional turns and the context message are preserved unchanged.
 
 ## Validating Data
 
@@ -106,6 +116,12 @@ This checks for:
 - Context message consistency
 - Minimum example count
 - Consecutive same-role messages (broken turn alternation)
+
+Pass `--fix` to remove exact-duplicate examples (identical messages, not just matching input text), or `--rewrite-context` to rewrite mismatched context messages to match your current config:
+
+```bash
+nanotune data validate --fix --rewrite-context
+```
 
 ## Tips
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -69,6 +69,22 @@ dataCommand
 	});
 
 dataCommand
+	.command('export <file>')
+	.description('Export training data to file (JSONL, CSV, or JSON)')
+	.option('-y, --yes', 'Skip the overwrite confirmation prompt (for scripts and CI)')
+	.action(async (file: string, options: {yes?: boolean}) => {
+		const {DataExportCommand} = await import('./commands/data/export.js');
+		// Without a TTY there is no way to answer the overwrite prompt, so require --yes.
+		if (!options.yes && !supportsRawMode()) {
+			console.error(interactiveRequiredMessage('data export'));
+			console.error('Pass --yes to export without confirmation.');
+			process.exitCode = 1;
+			return;
+		}
+		render(<DataExportCommand file={file} yes={options.yes} />);
+	});
+
+dataCommand
 	.command('list')
 	.alias('ls')
 	.description('View training data')
@@ -80,9 +96,19 @@ dataCommand
 dataCommand
 	.command('validate')
 	.description('Validate training data format and quality')
-	.action(async () => {
+	.option('--fix', 'Remove exact-duplicate examples')
+	.option(
+		'--rewrite-context',
+		"Rewrite each example's context message to match the current config",
+	)
+	.action(async (options: {fix?: boolean; rewriteContext?: boolean}) => {
 		const {DataValidateCommand} = await import('./commands/data/validate.js');
-		render(<DataValidateCommand />);
+		render(
+			<DataValidateCommand
+				fix={options.fix}
+				rewriteContext={options.rewriteContext}
+			/>,
+		);
 	});
 
 // Train command

--- a/src/commands/data/export.tsx
+++ b/src/commands/data/export.tsx
@@ -1,0 +1,150 @@
+import {existsSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {Spinner, StatusMessage} from '@inkjs/ui';
+import {Box, Text, useApp} from 'ink';
+import {useCallback, useEffect, useState} from 'react';
+import {
+	ExitHint,
+	Header,
+	useAutoExit,
+	useKeyInput,
+} from '../../components/index.js';
+import {configExists} from '../../lib/config.js';
+import {countExamples, type ExportResult, exportData} from '../../lib/data.js';
+
+interface Props {
+	file: string;
+	/** Skip the overwrite confirmation — needed to run under CI or in a pipeline. */
+	yes?: boolean;
+}
+
+export function DataExportCommand({file, yes}: Props) {
+	const {exit} = useApp();
+	const filePath = resolve(process.cwd(), file);
+	const fileExists = existsSync(filePath);
+	const [status, setStatus] = useState<
+		'confirm' | 'exporting' | 'done' | 'error'
+	>(!fileExists || yes ? 'exporting' : 'confirm');
+	const [result, setResult] = useState<ExportResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const count = configExists() ? countExamples() : 0;
+
+	const doExport = useCallback(() => {
+		try {
+			if (!configExists()) {
+				setError('Not a Nanotune project. Run `nanotune init` first.');
+				setStatus('error');
+				return;
+			}
+
+			const exportResult = exportData(filePath);
+			if (
+				exportResult.exported === 0 &&
+				exportResult.errors[0]?.startsWith('Unsupported')
+			) {
+				setError(exportResult.errors[0]);
+				setStatus('error');
+				return;
+			}
+
+			setResult(exportResult);
+			setStatus('done');
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Export failed');
+			setStatus('error');
+		}
+	}, [filePath]);
+
+	useEffect(() => {
+		if (status === 'exporting') {
+			doExport();
+		}
+	}, [status, doExport]);
+
+	useKeyInput(input => {
+		if (status === 'confirm') {
+			if (input.toLowerCase() === 'y') {
+				setStatus('exporting');
+			} else if (input.toLowerCase() === 'n' || input === '\x1b') {
+				exit();
+			}
+		} else if (status === 'done' || status === 'error') {
+			exit();
+		}
+	});
+
+	useAutoExit(status === 'done' || status === 'error', status === 'error');
+
+	if (!configExists()) {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Export Training Data" />
+				<StatusMessage variant="error">
+					Not a Nanotune project. Run `nanotune init` first.
+				</StatusMessage>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Header title="Export Training Data" />
+
+			{status === 'confirm' && (
+				<Box flexDirection="column">
+					<Text>
+						File: <Text color="cyan">{file}</Text>
+					</Text>
+					<Text>
+						Examples: <Text color="cyan">{count}</Text>
+					</Text>
+					<Text> </Text>
+					<Text color="yellow">File already exists.</Text>
+					<Text>
+						Overwrite it? <Text color="green">(y/n)</Text>
+					</Text>
+				</Box>
+			)}
+
+			{status === 'exporting' && <Spinner label="Exporting data..." />}
+
+			{status === 'done' && result && (
+				<Box flexDirection="column">
+					<StatusMessage variant="success">Export complete!</StatusMessage>
+					<Text> </Text>
+					<Text>
+						Exported: <Text color="green">{result.exported}</Text>
+					</Text>
+					{result.skipped > 0 && (
+						<Text>
+							Skipped: <Text color="yellow">{result.skipped}</Text>
+						</Text>
+					)}
+					{result.errors.length > 0 && (
+						<Box flexDirection="column" marginTop={1}>
+							<Text color="yellow">Warnings:</Text>
+							{result.errors.slice(0, 5).map((e, i) => (
+								<Text key={i} dimColor>
+									- {e}
+								</Text>
+							))}
+							{result.errors.length > 5 && (
+								<Text dimColor>... and {result.errors.length - 5} more</Text>
+							)}
+						</Box>
+					)}
+					<Text> </Text>
+					<ExitHint>Press any key to exit</ExitHint>
+				</Box>
+			)}
+
+			{status === 'error' && (
+				<Box flexDirection="column">
+					<StatusMessage variant="error">{error}</StatusMessage>
+					<Text> </Text>
+					<ExitHint>Press any key to exit</ExitHint>
+				</Box>
+			)}
+		</Box>
+	);
+}

--- a/src/commands/data/list.tsx
+++ b/src/commands/data/list.tsx
@@ -1,9 +1,17 @@
-import {StatusMessage} from '@inkjs/ui';
+import {StatusMessage, TextInput} from '@inkjs/ui';
 import {Box, Text, useApp} from 'ink';
 import {useState} from 'react';
 import {DataTable, Header, useKeyInput} from '../../components/index.js';
 import {configExists} from '../../lib/config.js';
-import {countTurns, deleteExample, loadTrainingData} from '../../lib/data.js';
+import {
+	countTurns,
+	deleteExample,
+	loadTrainingData,
+	updateTrainingExample,
+} from '../../lib/data.js';
+import type {ChatMessage} from '../../types/index.js';
+
+type EditField = 'input' | 'output';
 
 const PAGE_SIZE = 10;
 
@@ -19,11 +27,84 @@ export function DataListCommand() {
 	} | null>(null);
 	const [hasConfig] = useState(() => configExists());
 
+	const [editIndex, setEditIndex] = useState<number | null>(null);
+	const [editField, setEditField] = useState<EditField>('input');
+	const [editInput, setEditInput] = useState('');
+	const [editOutput, setEditOutput] = useState('');
+	const [editError, setEditError] = useState<string | null>(null);
+
 	const totalPages = Math.ceil(data.length / PAGE_SIZE);
 	const startIndex = page * PAGE_SIZE;
 	const pageData = data.slice(startIndex, startIndex + PAGE_SIZE);
 
+	const saveEdit = (userInput: string, assistantOutput: string) => {
+		if (editIndex === null) return;
+		try {
+			const original = data[editIndex];
+			const messages = original.messages;
+			const firstUserIdx = messages.findIndex(m => m.role === 'user');
+			const firstAssistantIdx = messages.findIndex(
+				(m, i) => m.role === 'assistant' && i > firstUserIdx,
+			);
+			const prefix = firstUserIdx >= 0 ? messages.slice(0, firstUserIdx) : [];
+			const suffix =
+				firstAssistantIdx >= 0
+					? messages.slice(firstAssistantIdx + 1)
+					: messages.slice(2);
+
+			const updated: {messages: ChatMessage[]} = {
+				messages: [
+					...prefix,
+					{role: 'user', content: userInput},
+					{role: 'assistant', content: assistantOutput},
+					...suffix,
+				],
+			};
+			updateTrainingExample(editIndex, updated);
+			setData(loadTrainingData());
+			setExpandedIndex(null);
+			setEditIndex(null);
+			setEditError(null);
+			setMessage({type: 'success', text: 'Example updated'});
+			setTimeout(() => setMessage(null), 2000);
+		} catch (err) {
+			setEditError(err instanceof Error ? err.message : 'Update failed');
+		}
+	};
+
+	const handleEditInputSubmit = (value: string) => {
+		if (value.trim()) {
+			setEditInput(value.trim());
+			setEditField('output');
+		}
+	};
+
+	const handleEditOutputSubmit = (value: string) => {
+		if (!value.trim()) {
+			setEditError('Output cannot be empty');
+			return;
+		}
+		setEditOutput(value.trim());
+		saveEdit(editInput, value.trim());
+	};
+
+	useKeyInput((_input, key) => {
+		if (editIndex === null) return;
+
+		if (key.escape) {
+			setEditIndex(null);
+			setEditError(null);
+			return;
+		}
+
+		if (key.tab) {
+			setEditField(f => (f === 'input' ? 'output' : 'input'));
+		}
+	});
+
 	useKeyInput((input, key) => {
+		if (editIndex !== null) return;
+
 		if (key.escape || input === 'q') {
 			exit();
 		}
@@ -87,6 +168,21 @@ export function DataListCommand() {
 				}
 			}
 		}
+
+		if (input === 'e') {
+			const globalIndex = startIndex + selectedIndex;
+			if (globalIndex < data.length) {
+				const ex = data[globalIndex];
+				const userMsg = ex.messages.find(m => m.role === 'user');
+				const assistantMsg = ex.messages.find(m => m.role === 'assistant');
+				setEditIndex(globalIndex);
+				setEditInput(userMsg?.content ?? '');
+				setEditOutput(assistantMsg?.content ?? '');
+				setEditField('input');
+				setEditError(null);
+				setExpandedIndex(null);
+			}
+		}
 	});
 
 	if (!hasConfig) {
@@ -114,6 +210,66 @@ export function DataListCommand() {
 
 	const expandedExample =
 		expandedIndex !== null ? pageData[expandedIndex] : null;
+
+	const editingExample = editIndex !== null ? data[editIndex] : null;
+	const editExtraTurns = editingExample ? countTurns(editingExample) - 1 : 0;
+
+	if (editingExample && editIndex !== null) {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title={`Editing Example #${editIndex + 1}`} />
+
+				{editError && (
+					<Box marginBottom={1}>
+						<StatusMessage variant="error">{editError}</StatusMessage>
+					</Box>
+				)}
+
+				{editExtraTurns > 0 && (
+					<Box marginBottom={1}>
+						<Text dimColor>
+							{editExtraTurns} additional turn{editExtraTurns > 1 ? 's' : ''}{' '}
+							preserved, not edited here.
+						</Text>
+					</Box>
+				)}
+
+				<Box flexDirection="column" marginBottom={1}>
+					<Text color={editField === 'input' ? 'yellow' : 'white'}>
+						User input:
+					</Text>
+					<Box borderStyle="round" paddingX={1}>
+						{editField === 'input' ? (
+							<TextInput
+								defaultValue={editInput}
+								onSubmit={handleEditInputSubmit}
+							/>
+						) : (
+							<Text>{editInput || <Text dimColor>Empty</Text>}</Text>
+						)}
+					</Box>
+				</Box>
+
+				<Box flexDirection="column" marginBottom={1}>
+					<Text color={editField === 'output' ? 'yellow' : 'white'}>
+						Expected output:
+					</Text>
+					<Box borderStyle="round" paddingX={1}>
+						{editField === 'output' ? (
+							<TextInput
+								defaultValue={editOutput}
+								onSubmit={handleEditOutputSubmit}
+							/>
+						) : (
+							<Text>{editOutput || <Text dimColor>Empty</Text>}</Text>
+						)}
+					</Box>
+				</Box>
+
+				<Text dimColor>[Enter] Submit [Tab] Switch field [Esc] Cancel</Text>
+			</Box>
+		);
+	}
 
 	return (
 		<Box flexDirection="column" padding={1}>
@@ -179,8 +335,8 @@ export function DataListCommand() {
 
 					<Text> </Text>
 					<Text dimColor>
-						[Up/Down] Navigate [Left/Right] Page [Enter] Expand/collapse [d]
-						Delete [q] Quit
+						[Up/Down] Navigate [Left/Right] Page [Enter] Expand/collapse [e]
+						Edit [d] Delete [q] Quit
 					</Text>
 				</Box>
 			)}

--- a/src/commands/data/list.tsx
+++ b/src/commands/data/list.tsx
@@ -7,6 +7,7 @@ import {
 	countTurns,
 	deleteExample,
 	loadTrainingData,
+	mergeEditedTurn,
 	updateTrainingExample,
 } from '../../lib/data.js';
 import type {ChatMessage} from '../../types/index.js';
@@ -41,24 +42,8 @@ export function DataListCommand() {
 		if (editIndex === null) return;
 		try {
 			const original = data[editIndex];
-			const messages = original.messages;
-			const firstUserIdx = messages.findIndex(m => m.role === 'user');
-			const firstAssistantIdx = messages.findIndex(
-				(m, i) => m.role === 'assistant' && i > firstUserIdx,
-			);
-			const prefix = firstUserIdx >= 0 ? messages.slice(0, firstUserIdx) : [];
-			const suffix =
-				firstAssistantIdx >= 0
-					? messages.slice(firstAssistantIdx + 1)
-					: messages.slice(2);
-
 			const updated: {messages: ChatMessage[]} = {
-				messages: [
-					...prefix,
-					{role: 'user', content: userInput},
-					{role: 'assistant', content: assistantOutput},
-					...suffix,
-				],
+				messages: mergeEditedTurn(original.messages, userInput, assistantOutput),
 			};
 			updateTrainingExample(editIndex, updated);
 			setData(loadTrainingData());

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -12,9 +12,21 @@ import {
 	loadConfig,
 	resolveContextMessage,
 } from '../../lib/config.js';
-import {countExamples, validateTrainingData} from '../../lib/data.js';
+import {
+	countExamples,
+	type ContextFixResult,
+	type DedupeResult,
+	dedupeExamples,
+	fixContextMessages,
+	validateTrainingData,
+} from '../../lib/data.js';
 
-export function DataValidateCommand() {
+interface Props {
+	fix?: boolean;
+	rewriteContext?: boolean;
+}
+
+export function DataValidateCommand({fix, rewriteContext}: Props) {
 	const {exit} = useApp();
 	const hasConfig = configExists();
 
@@ -24,6 +36,19 @@ export function DataValidateCommand() {
 		}
 	});
 
+	let dedupeResult: DedupeResult | null = null;
+	let contextFixResult: ContextFixResult | null = null;
+	if (hasConfig) {
+		if (fix) {
+			dedupeResult = dedupeExamples();
+		}
+		if (rewriteContext) {
+			contextFixResult = fixContextMessages(resolveContextMessage(loadConfig()));
+		}
+	}
+
+	// Re-validate after fixes are applied so the report reflects the data
+	// actually left on disk.
 	const count = hasConfig ? countExamples() : 0;
 	const result = hasConfig
 		? validateTrainingData(resolveContextMessage(loadConfig()))
@@ -54,6 +79,38 @@ export function DataValidateCommand() {
 					{count}
 				</Text>
 			</Box>
+
+			{(dedupeResult || contextFixResult) && (
+				<Box flexDirection="column" marginBottom={1}>
+					<Text bold>Fixes applied:</Text>
+					{dedupeResult && (
+						<Box>
+							<StatusBadge
+								status={dedupeResult.removedCount > 0 ? 'success' : 'pending'}
+							/>
+							<Text>
+								{' '}
+								{dedupeResult.removedCount > 0
+									? `Removed ${dedupeResult.removedCount} exact-duplicate example${dedupeResult.removedCount > 1 ? 's' : ''}`
+									: 'No exact duplicates found'}
+							</Text>
+						</Box>
+					)}
+					{contextFixResult && (
+						<Box>
+							<StatusBadge
+								status={contextFixResult.fixedCount > 0 ? 'success' : 'pending'}
+							/>
+							<Text>
+								{' '}
+								{contextFixResult.fixedCount > 0
+									? `Rewrote context message on ${contextFixResult.fixedCount} example${contextFixResult.fixedCount > 1 ? 's' : ''}`
+									: 'No context-message mismatches to rewrite'}
+							</Text>
+						</Box>
+					)}
+				</Box>
+			)}
 
 			{result.valid ? (
 				<StatusMessage variant="success">Training data is valid!</StatusMessage>

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -39,11 +39,13 @@ export function DataValidateCommand({fix, rewriteContext}: Props) {
 	let dedupeResult: DedupeResult | null = null;
 	let contextFixResult: ContextFixResult | null = null;
 	if (hasConfig) {
-		if (fix) {
-			dedupeResult = dedupeExamples();
-		}
+		// Rewrite context first: examples that only become identical after
+		// context normalization must still be caught by dedupe in this pass.
 		if (rewriteContext) {
 			contextFixResult = fixContextMessages(resolveContextMessage(loadConfig()));
+		}
+		if (fix) {
+			dedupeResult = dedupeExamples();
 		}
 	}
 

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -19,6 +19,7 @@ import {
   importFromJSONL,
   importData,
   loadTrainingData,
+  mergeEditedTurn,
   parseCSV,
   splitTrainValidation,
   updateExample,
@@ -325,6 +326,23 @@ test.serial("fixContextMessages only rewrites index 0 on a multi-turn example", 
   t.is(data[0].messages[3].content, "turn2 user");
   t.is(data[0].messages[4].content, "turn2 assistant");
 });
+
+test.serial(
+  "running fixContextMessages before dedupeExamples catches duplicates that only match after normalization",
+  (t) => {
+    appendToTrainingData({ contextMessage: DEV_CTX, userInput: "same", assistantOutput: "same-out" });
+    appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "same", assistantOutput: "same-out" });
+
+    // The two examples only become byte-identical once their context
+    // messages are normalized to match config — this is the order
+    // `nanotune data validate --fix --rewrite-context` relies on.
+    fixContextMessages(SYSTEM_CTX);
+    const dedupeResult = dedupeExamples();
+
+    t.is(dedupeResult.removedCount, 1);
+    t.is(loadTrainingData().length, 1);
+  },
+);
 
 // ── importFromCSV ─────────────────────────────────────────────────────
 
@@ -652,6 +670,110 @@ test.serial("updateTrainingExample replaces with multi-turn example", (t) => {
   t.is(data.length, 1);
   t.is(data[0].messages.length, 5);
   t.is(data[0].messages[3].content, "Turn 2");
+});
+
+// ── mergeEditedTurn ────────────────────────────────────────────────────
+
+test("mergeEditedTurn replaces user/assistant in place, preserving context", (t) => {
+  const result = mergeEditedTurn(
+    [
+      { role: "system", content: "ctx" },
+      { role: "user", content: "old-in" },
+      { role: "assistant", content: "old-out" },
+    ],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "ctx" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+  ]);
+});
+
+test("mergeEditedTurn only touches the first turn in a multi-turn example", (t) => {
+  const result = mergeEditedTurn(
+    [
+      { role: "system", content: "ctx" },
+      { role: "user", content: "old-in" },
+      { role: "assistant", content: "old-out" },
+      { role: "user", content: "turn2-in" },
+      { role: "assistant", content: "turn2-out" },
+    ],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "ctx" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+    { role: "user", content: "turn2-in" },
+    { role: "assistant", content: "turn2-out" },
+  ]);
+});
+
+test("mergeEditedTurn inserts a missing assistant message after the user message", (t) => {
+  const result = mergeEditedTurn(
+    [
+      { role: "system", content: "ctx" },
+      { role: "user", content: "old-in" },
+    ],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "ctx" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+  ]);
+});
+
+test("mergeEditedTurn inserts a missing user message before the assistant message", (t) => {
+  const result = mergeEditedTurn(
+    [
+      { role: "system", content: "ctx" },
+      { role: "assistant", content: "old-out" },
+    ],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "ctx" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+  ]);
+});
+
+test("mergeEditedTurn preserves an unrecognized message and appends a new turn when neither role is present", (t) => {
+  const result = mergeEditedTurn(
+    [{ role: "system", content: "stray context-only example" }],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "stray context-only example" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+  ]);
+});
+
+test("mergeEditedTurn preserves multiple non-user/assistant messages untouched", (t) => {
+  const result = mergeEditedTurn(
+    [
+      { role: "system", content: "ctx1" },
+      { role: "developer", content: "ctx2" },
+      { role: "user", content: "old-in" },
+      { role: "assistant", content: "old-out" },
+    ],
+    "new-in",
+    "new-out",
+  );
+  t.deepEqual(result, [
+    { role: "system", content: "ctx1" },
+    { role: "developer", content: "ctx2" },
+    { role: "user", content: "new-in" },
+    { role: "assistant", content: "new-out" },
+  ]);
 });
 
 test.serial("countTurns counts user messages as turns", (t) => {

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -7,7 +7,13 @@ import {
   appendTrainingExample,
   countExamples,
   countTurns,
+  dedupeExamples,
   deleteExample,
+  exportData,
+  exportToCSV,
+  exportToJSON,
+  exportToJSONL,
+  fixContextMessages,
   importFromCSV,
   importFromJSON,
   importFromJSONL,
@@ -204,6 +210,122 @@ test.serial("validateTrainingData warns when under 50 examples", (t) => {
   t.true(result.warnings.some((w) => w.includes("Recommend at least 50")));
 });
 
+// ── dedupeExamples ────────────────────────────────────────────────────
+
+test.serial("dedupeExamples removes an exact-duplicate example", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "C", assistantOutput: "D" });
+
+  const result = dedupeExamples();
+  t.is(result.removedCount, 1);
+  t.deepEqual(result.removedIndexes, [2]);
+
+  const data = loadTrainingData();
+  t.is(data.length, 2);
+  t.is(data[0].messages[1].content, "A");
+  t.is(data[1].messages[1].content, "C");
+});
+
+test.serial("dedupeExamples does nothing when no duplicates exist", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "C", assistantOutput: "D" });
+
+  const result = dedupeExamples();
+  t.is(result.removedCount, 0);
+  t.deepEqual(result.removedIndexes, []);
+  t.is(loadTrainingData().length, 2);
+});
+
+test.serial("dedupeExamples keeps examples with the same input but different output", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "same", assistantOutput: "A" });
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "same", assistantOutput: "B" });
+
+  const result = dedupeExamples();
+  t.is(result.removedCount, 0);
+  t.is(loadTrainingData().length, 2);
+});
+
+test.serial("dedupeExamples keeps identical turns with different context messages", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: DEV_CTX, userInput: "A", assistantOutput: "B" });
+
+  const result = dedupeExamples();
+  t.is(result.removedCount, 0);
+  t.is(loadTrainingData().length, 2);
+});
+
+test.serial("dedupeExamples operates on valid.jsonl independently when isEval is true", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" }, true);
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" }, true);
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "X", assistantOutput: "Y" });
+
+  const result = dedupeExamples(true);
+  t.is(result.removedCount, 1);
+  t.is(loadTrainingData(true).length, 1);
+  t.is(loadTrainingData(false).length, 1);
+});
+
+// ── fixContextMessages ────────────────────────────────────────────────
+
+test.serial("fixContextMessages rewrites a mismatched context message", (t) => {
+  appendToTrainingData({ contextMessage: DEV_CTX, userInput: "A", assistantOutput: "B" });
+
+  const result = fixContextMessages(SYSTEM_CTX);
+  t.is(result.fixedCount, 1);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages[0].role, "system");
+  t.is(data[0].messages[0].content, "You are helpful.");
+  t.is(data[0].messages[1].content, "A");
+  t.is(data[0].messages[2].content, "B");
+});
+
+test.serial("fixContextMessages does nothing when already matching", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+
+  const result = fixContextMessages(SYSTEM_CTX);
+  t.is(result.fixedCount, 0);
+});
+
+test.serial("fixContextMessages does not insert a context message when none exists", (t) => {
+  const bare: TrainingExample = {
+    messages: [
+      { role: "user", content: "A" },
+      { role: "assistant", content: "B" },
+    ],
+  };
+  writeFileSync(join(DATA_DIR, "train.jsonl"), JSON.stringify(bare) + "\n");
+
+  const result = fixContextMessages(SYSTEM_CTX);
+  t.is(result.fixedCount, 0);
+  t.is(loadTrainingData()[0].messages[0].role, "user");
+});
+
+test.serial("fixContextMessages only rewrites index 0 on a multi-turn example", (t) => {
+  const multiTurn: TrainingExample = {
+    messages: [
+      DEV_CTX,
+      { role: "user", content: "turn1 user" },
+      { role: "assistant", content: "turn1 assistant" },
+      { role: "user", content: "turn2 user" },
+      { role: "assistant", content: "turn2 assistant" },
+    ],
+  };
+  writeFileSync(join(DATA_DIR, "train.jsonl"), JSON.stringify(multiTurn) + "\n");
+
+  const result = fixContextMessages(SYSTEM_CTX);
+  t.is(result.fixedCount, 1);
+
+  const data = loadTrainingData();
+  t.is(data[0].messages.length, 5);
+  t.is(data[0].messages[0].role, "system");
+  t.is(data[0].messages[1].content, "turn1 user");
+  t.is(data[0].messages[2].content, "turn1 assistant");
+  t.is(data[0].messages[3].content, "turn2 user");
+  t.is(data[0].messages[4].content, "turn2 assistant");
+});
+
 // ── importFromCSV ─────────────────────────────────────────────────────
 
 test.serial("importFromCSV imports valid rows with context message role", (t) => {
@@ -342,6 +464,139 @@ test.serial("importData returns error for unsupported format", (t) => {
   const result = importData(txtPath, SYSTEM_CTX);
   t.is(result.imported, 0);
   t.true(result.errors[0].includes("Unsupported file format"));
+});
+
+// ── exportToJSONL / exportToJSON / exportToCSV / exportData ───────────
+
+test.serial("exportToJSONL round-trips through importFromJSONL", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: DEV_CTX, userInput: "C", assistantOutput: "D" });
+
+  const outPath = join(TEST_DIR, "out.jsonl");
+  const exportResult = exportToJSONL(outPath);
+  t.is(exportResult.exported, 2);
+
+  const original = loadTrainingData();
+  rmSync(join(DATA_DIR, "train.jsonl"));
+  const importResult = importFromJSONL(outPath, SYSTEM_CTX);
+  t.is(importResult.imported, 2);
+  t.deepEqual(loadTrainingData(), original);
+});
+
+test.serial("exportToJSON round-trips through importFromJSON", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "C", assistantOutput: "D" });
+
+  const outPath = join(TEST_DIR, "out.json");
+  const exportResult = exportToJSON(outPath);
+  t.is(exportResult.exported, 2);
+
+  const original = loadTrainingData();
+  rmSync(join(DATA_DIR, "train.jsonl"));
+  const importResult = importFromJSON(outPath, SYSTEM_CTX);
+  t.is(importResult.imported, 2);
+  t.deepEqual(loadTrainingData(), original);
+});
+
+test.serial("exportToCSV round-trips single-turn data through importFromCSV", (t) => {
+  appendToTrainingData({ contextMessage: DEV_CTX, userInput: "list files", assistantOutput: "ls" });
+  appendToTrainingData({ contextMessage: DEV_CTX, userInput: "show dir", assistantOutput: "pwd" });
+
+  const outPath = join(TEST_DIR, "out.csv");
+  const exportResult = exportToCSV(outPath);
+  t.is(exportResult.exported, 2);
+  t.is(exportResult.skipped, 0);
+
+  const content = readFileSync(outPath, "utf-8");
+  t.true(content.startsWith("input,output\n"));
+
+  rmSync(join(DATA_DIR, "train.jsonl"));
+  const importResult = importFromCSV(outPath, DEV_CTX);
+  t.is(importResult.imported, 2);
+  const data = loadTrainingData();
+  t.is(data[0].messages[1].content, "list files");
+  t.is(data[0].messages[2].content, "ls");
+  t.is(data[1].messages[1].content, "show dir");
+  t.is(data[1].messages[2].content, "pwd");
+});
+
+test.serial("exportToCSV skips multi-turn examples instead of truncating them", (t) => {
+  const multiTurn: TrainingExample = {
+    messages: [
+      SYSTEM_CTX,
+      { role: "user", content: "turn1" },
+      { role: "assistant", content: "reply1" },
+      { role: "user", content: "turn2" },
+      { role: "assistant", content: "reply2" },
+    ],
+  };
+  appendTrainingExample(multiTurn);
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "single", assistantOutput: "turn" });
+
+  const outPath = join(TEST_DIR, "out.csv");
+  const result = exportToCSV(outPath);
+  t.is(result.exported, 1);
+  t.is(result.skipped, 1);
+  t.true(result.errors[0].includes("multi-turn"));
+});
+
+test.serial("exportToCSV escapes commas, quotes, and newlines and round-trips through parseCSV", (t) => {
+  appendToTrainingData({
+    contextMessage: SYSTEM_CTX,
+    userInput: 'say "hi", then leave\nplease',
+    assistantOutput: "ok",
+  });
+
+  const outPath = join(TEST_DIR, "out.csv");
+  exportToCSV(outPath);
+
+  const content = readFileSync(outPath, "utf-8");
+  const rows = parseCSV(content);
+  t.is(rows[1][0], 'say "hi", then leave\nplease');
+  t.is(rows[1][1], "ok");
+});
+
+test.serial("exportData dispatches to correct writer by extension", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "A", assistantOutput: "B" });
+
+  const jsonlResult = exportData(join(TEST_DIR, "out.jsonl"));
+  t.is(jsonlResult.exported, 1);
+  const jsonResult = exportData(join(TEST_DIR, "out.json"));
+  t.is(jsonResult.exported, 1);
+  const csvResult = exportData(join(TEST_DIR, "out.csv"));
+  t.is(csvResult.exported, 1);
+});
+
+test.serial("exportData returns error for unsupported format", (t) => {
+  const result = exportData(join(TEST_DIR, "out.txt"));
+  t.is(result.exported, 0);
+  t.true(result.errors[0].includes("Unsupported file format"));
+});
+
+test.serial("export writers operate on valid.jsonl independently when isEval is true", (t) => {
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "eval-a", assistantOutput: "eval-b" }, true);
+  appendToTrainingData({ contextMessage: SYSTEM_CTX, userInput: "train-a", assistantOutput: "train-b" });
+
+  const outPath = join(TEST_DIR, "out-eval.jsonl");
+  const result = exportToJSONL(outPath, true);
+  t.is(result.exported, 1);
+
+  const content = JSON.parse(readFileSync(outPath, "utf-8").trim());
+  t.is(content.messages[1].content, "eval-a");
+});
+
+test.serial("export writers produce a valid, parseable empty file with zero examples", (t) => {
+  const jsonlPath = join(TEST_DIR, "empty.jsonl");
+  exportToJSONL(jsonlPath);
+  t.is(readFileSync(jsonlPath, "utf-8"), "");
+
+  const jsonPath = join(TEST_DIR, "empty.json");
+  exportToJSON(jsonPath);
+  t.deepEqual(JSON.parse(readFileSync(jsonPath, "utf-8")), []);
+
+  const csvPath = join(TEST_DIR, "empty.csv");
+  exportToCSV(csvPath);
+  t.is(readFileSync(csvPath, "utf-8"), "input,output\n");
 });
 
 // ── countExamples / loadTrainingData edge cases ───────────────────────

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -254,6 +254,85 @@ export function validateTrainingData(
 	};
 }
 
+export interface DedupeResult {
+	removedCount: number;
+	/** 1-based positions (in the original file) that were removed. */
+	removedIndexes: number[];
+}
+
+/**
+ * Remove exact-duplicate examples: same messages (role + content, in order).
+ * Deliberately stricter than validateTrainingData's duplicate warning (which
+ * only compares the first user message) — removal must be provably safe, so
+ * two examples that merely share the same input but differ in output or
+ * context message are left alone.
+ */
+export function dedupeExamples(isEval = false): DedupeResult {
+	const examples = loadTrainingData(isEval);
+	const seen = new Set<string>();
+	const kept: TrainingExample[] = [];
+	const removedIndexes: number[] = [];
+
+	examples.forEach((ex, i) => {
+		const key = JSON.stringify(
+			ex.messages.map(m => ({role: m.role, content: m.content})),
+		);
+		if (seen.has(key)) {
+			removedIndexes.push(i + 1);
+			return;
+		}
+		seen.add(key);
+		kept.push(ex);
+	});
+
+	if (removedIndexes.length > 0) {
+		saveTrainingData(kept, isEval);
+	}
+
+	return {removedCount: removedIndexes.length, removedIndexes};
+}
+
+export interface ContextFixResult {
+	fixedCount: number;
+}
+
+/**
+ * Rewrite each example's context message (messages[0]) to match the given
+ * contextMessage, but only when a context message already exists. Never
+ * inserts one where the example starts with a user message, since that
+ * would change the example's shape rather than just fix a mismatch.
+ */
+export function fixContextMessages(
+	contextMessage: ChatMessage,
+	isEval = false,
+): ContextFixResult {
+	const examples = loadTrainingData(isEval);
+	let fixedCount = 0;
+
+	const updated = examples.map(ex => {
+		const first = ex.messages[0];
+		if (!first || first.role === 'user' || first.role === 'assistant') {
+			return ex;
+		}
+		if (first.role === contextMessage.role && first.content === contextMessage.content) {
+			return ex;
+		}
+		fixedCount++;
+		return {
+			messages: [
+				{role: contextMessage.role, content: contextMessage.content},
+				...ex.messages.slice(1),
+			],
+		};
+	});
+
+	if (fixedCount > 0) {
+		saveTrainingData(updated, isEval);
+	}
+
+	return {fixedCount};
+}
+
 export interface ImportResult {
 	imported: number;
 	skipped: number;
@@ -527,6 +606,88 @@ export function importData(
 		default:
 			return {
 				imported: 0,
+				skipped: 0,
+				errors: [`Unsupported file format: ${ext}`],
+			};
+	}
+}
+
+export interface ExportResult {
+	exported: number;
+	skipped: number;
+	errors: string[];
+}
+
+export function exportToJSONL(filePath: string, isEval = false): ExportResult {
+	const examples = loadTrainingData(isEval);
+	const content = examples.map(ex => JSON.stringify(ex)).join('\n');
+	writeFileSync(filePath, examples.length > 0 ? `${content}\n` : '');
+	return {exported: examples.length, skipped: 0, errors: []};
+}
+
+export function exportToJSON(filePath: string, isEval = false): ExportResult {
+	const examples = loadTrainingData(isEval);
+	writeFileSync(filePath, `${JSON.stringify(examples, null, 2)}\n`);
+	return {exported: examples.length, skipped: 0, errors: []};
+}
+
+function csvEscape(value: string): string {
+	if (/[",\r\n]/.test(value)) {
+		return `"${value.replace(/"/g, '""')}"`;
+	}
+	return value;
+}
+
+/**
+ * CSV can only represent a single input/output pair per row, with no room
+ * for a context message. Multi-turn examples are skipped (not truncated) so
+ * that exporting then re-importing never silently drops turns.
+ */
+export function exportToCSV(filePath: string, isEval = false): ExportResult {
+	const examples = loadTrainingData(isEval);
+	const rows: string[] = ['input,output'];
+	let exported = 0;
+	let skipped = 0;
+	const errors: string[] = [];
+
+	examples.forEach((ex, i) => {
+		if (countTurns(ex) > 1) {
+			skipped++;
+			errors.push(
+				`Example ${i + 1}: multi-turn example cannot be represented in CSV, skipped`,
+			);
+			return;
+		}
+
+		const user = ex.messages.find(m => m.role === 'user');
+		const assistant = ex.messages.find(m => m.role === 'assistant');
+		if (!user?.content || !assistant?.content) {
+			skipped++;
+			errors.push(`Example ${i + 1}: missing user or assistant message, skipped`);
+			return;
+		}
+
+		rows.push(`${csvEscape(user.content)},${csvEscape(assistant.content)}`);
+		exported++;
+	});
+
+	writeFileSync(filePath, `${rows.join('\n')}\n`);
+	return {exported, skipped, errors};
+}
+
+export function exportData(filePath: string, isEval = false): ExportResult {
+	const ext = filePath.toLowerCase().split('.').pop();
+
+	switch (ext) {
+		case 'csv':
+			return exportToCSV(filePath, isEval);
+		case 'jsonl':
+			return exportToJSONL(filePath, isEval);
+		case 'json':
+			return exportToJSON(filePath, isEval);
+		default:
+			return {
+				exported: 0,
 				skipped: 0,
 				errors: [`Unsupported file format: ${ext}`],
 			};

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -115,6 +115,41 @@ export function updateTrainingExample(
 	}
 }
 
+/**
+ * Replaces the first user/assistant turn in `messages` with new content,
+ * leaving every other message untouched — regardless of shape. Handles
+ * examples missing a user and/or assistant message by inserting rather than
+ * guessing a position, so malformed data is never silently dropped.
+ */
+export function mergeEditedTurn(
+	messages: ChatMessage[],
+	userInput: string,
+	assistantOutput: string,
+): ChatMessage[] {
+	const userIdx = messages.findIndex(m => m.role === 'user');
+	const assistantIdx = messages.findIndex(m => m.role === 'assistant');
+
+	const updated = [...messages];
+	if (userIdx >= 0) updated[userIdx] = {role: 'user', content: userInput};
+	if (assistantIdx >= 0)
+		updated[assistantIdx] = {role: 'assistant', content: assistantOutput};
+
+	if (userIdx === -1 && assistantIdx === -1) {
+		updated.push(
+			{role: 'user', content: userInput},
+			{role: 'assistant', content: assistantOutput},
+		);
+	} else if (userIdx === -1) {
+		updated.splice(assistantIdx, 0, {role: 'user', content: userInput});
+	} else if (assistantIdx === -1) {
+		updated.splice(userIdx + 1, 0, {
+			role: 'assistant',
+			content: assistantOutput,
+		});
+	}
+	return updated;
+}
+
 export function updateExample(
 	index: number,
 	example: {


### PR DESCRIPTION
## Description

Finishes data editing (closes #64): wires the already-implemented `updateTrainingExample` into `nanotune data list` behind an `e` key, adds `nanotune data validate --fix` / `--rewrite-context`, and adds `nanotune data export <file>`.

- **Edit (`e` key in `data list`)**: edits an example's first user/assistant turn in place, reusing `data add`'s input-flow UI. Uses `updateTrainingExample` (not the single-turn `updateExample`) so the original context message and any additional turns are preserved untouched.
- **`data validate --fix`**: removes only exact-duplicate examples (full message-array equality stricter than the existing "duplicate input" warning, so it never deletes anything that isn't provably safe to delete).
- **`data validate --rewrite-context`**: separate opt-in flag that rewrites a mismatched context message to match the current config, without ever inserting one where an example has none. Both flags report exactly how many examples they changed.
- **`data export <file>`**: mirrors `data import`'s JSONL/CSV/JSON format detection. JSONL/JSON round-trip exactly; CSV skips (never truncates) multi-turn examples, since CSV can't represent them and truncating would silently lose data.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (targeted run — see note below)
- [x] New tests added for new functionality (15 new AVA tests in `src/lib/data.spec.ts` covering `dedupeExamples`, `fixContextMessages`, and all four export functions)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate/export) — built the CLI and ran it against a scratch project: seeded duplicate/mismatched-context/multi-turn examples, ran `validate` and `validate --fix --rewrite-context` (confirmed exact on-disk changes), exported to all three formats, round-tripped a JSONL export back through `data import` to a byte-identical file. Could **not** interactively test the `data list` edit UI itself  Ink's raw-mode TUI needs a real TTY, unavailable in this tool environment.
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [ ] Code follows project style guidelines (`pnpm format`) — **not run**; this repo's checkout has a pre-existing CRLF/LF mismatch on Windows that makes `pnpm format` rewrite line endings across every file in the repo, not just the changed ones. Please run `pnpm format` locally (or in CI) rather than trusting this box.
- [x] Self-review completed
- [x] Documentation updated (`docs/commands/data.md`, `docs/guides/training-data.md`)
- [x] No breaking changes