### PR TITLE
feat: save chat transcripts and promote exchanges to training data

### DIFF
--- a/docs/commands/chat.md
+++ b/docs/commands/chat.md
@@ -37,6 +37,8 @@ nanotune chat
 | `/help` | Show available commands |
 | `/reset`, `/clear` | Clear conversation history |
 | `/system <text>` | Replace the system message and reset history |
+| `/save [file]` | Save the transcript to JSON (default: `.nanotune/chats/<timestamp>.json`) |
+| `/keep` | Append the last exchange to `train.jsonl` as a training example |
 | `/stats` | Show session token statistics |
 | `/exit`, `/quit` | Leave the chat (`Esc` also exits when idle) |
 
@@ -71,6 +73,47 @@ TTFT 142ms · 38.4 tok/s · 87 tokens
 - **tok/s** — generation throughput
 - **tokens** — tokens generated for that reply
 
+## Saving Your Session
+
+Chat is where you find failure modes — the prompt that drifts, the format the model keeps getting wrong. `/keep` and `/save` turn those moments into training data without leaving the REPL.
+
+`/keep` appends the last user/assistant exchange to `.nanotune/data/train.jsonl` as a training example, using the session's system message as the example's first message — the same shape [`nanotune data add`](data.md) produces, and it confirms inline with the new total example count. A common loop is to tighten the system message, retry the prompt, and keep the reply once it looks right:
+
+```
+> write a haiku about disk usage
+Sure! Here's a haiku about disk usage for you: ...
+
+> /system Reply with the poem and nothing else.
+> write a haiku about disk usage
+Blocks fill quietly / ...
+
+> /keep
+```
+
+`/keep` reports `Nothing to keep yet.` when there is no completed exchange, and `No system message set. Use /system <text> first.` when the session has no system message.
+
+`/save` writes the full transcript — including the system message as its first message — to JSON. With no argument it goes to `.nanotune/chats/<timestamp>.json`, creating the directory if it is missing; `/save runs/terse-bash.json` writes to that path instead, relative to the current directory, creating parent directories. If nothing has been said yet it reports `Nothing to save yet.` and writes no file.
+
+The saved file is an array holding a single object with a `messages` array:
+
+```json
+[
+  {
+    "messages": [
+      {"role": "system", "content": "You are a terse Bash command generator."},
+      {"role": "user", "content": "list files by size"},
+      {"role": "assistant", "content": "ls -lS"}
+    ]
+  }
+]
+```
+
+That is exactly the shape [`nanotune data import`](data.md) accepts, so a saved session replays straight back into training data:
+
+```bash
+nanotune data import .nanotune/chats/2026-08-12T09-41-07-482Z.json
+```
+
 ## Chat Template Handling
 
 `chat` talks to `llama-server`'s OpenAI-compatible `/v1/chat/completions` endpoint, so the chat template baked into the GGUF (ChatML, Llama-3 tags, and so on) is applied automatically. This is the same wire format training uses, which means what you see in `chat` reflects what the model actually learned.
@@ -99,3 +142,4 @@ nanotune chat --preset low
 - [`nanotune export`](export.md) — Producing the GGUF that `chat` loads
 - [`nanotune benchmark`](benchmark.md) — Scoring the model against a test dataset
 - [Benchmarking Guide](../guides/benchmarking.md) — Turning what you find in chat into repeatable tests
+- [`nanotune data`](data.md) — Importing a saved transcript back into your training set

--- a/docs/commands/chat.md
+++ b/docs/commands/chat.md
@@ -37,7 +37,7 @@ nanotune chat
 | `/help` | Show available commands |
 | `/reset`, `/clear` | Clear conversation history |
 | `/system <text>` | Replace the system message and reset history |
-| `/save [file]` | Save the transcript to JSON (default: `.nanotune/chats/<timestamp>.json`) |
+| `/save [file] [--force]` | Save the transcript to JSON (default: `.nanotune/chats/<timestamp>.json`) |
 | `/keep` | Append the last exchange to `train.jsonl` as a training example |
 | `/stats` | Show session token statistics |
 | `/exit`, `/quit` | Leave the chat (`Esc` also exits when idle) |
@@ -77,7 +77,7 @@ TTFT 142ms · 38.4 tok/s · 87 tokens
 
 Chat is where you find failure modes — the prompt that drifts, the format the model keeps getting wrong. `/keep` and `/save` turn those moments into training data without leaving the REPL.
 
-`/keep` appends the last user/assistant exchange to `.nanotune/data/train.jsonl` as a training example, using the session's system message as the example's first message — the same shape [`nanotune data add`](data.md) produces, and it confirms inline with the new total example count. A common loop is to tighten the system message, retry the prompt, and keep the reply once it looks right:
+`/keep` appends the last user/assistant exchange to `.nanotune/data/train.jsonl` as a training example — the same shape [`nanotune data add`](data.md) produces — and confirms inline with the new total example count. When the session has a system message it becomes the example's first message; when there is none, the example is just the user/assistant pair. A common loop is to tighten the system message, retry the prompt, and keep the reply once it looks right:
 
 ```
 > write a haiku about disk usage
@@ -90,9 +90,18 @@ Blocks fill quietly / ...
 > /keep
 ```
 
-`/keep` reports `Nothing to keep yet.` when there is no completed exchange, and `No system message set. Use /system <text> first.` when the session has no system message.
+`/keep` reports `Nothing to keep yet.` when there is no completed exchange.
 
-`/save` writes the full transcript — including the system message as its first message — to JSON. With no argument it goes to `.nanotune/chats/<timestamp>.json`, creating the directory if it is missing; `/save runs/terse-bash.json` writes to that path instead, relative to the current directory, creating parent directories. If nothing has been said yet it reports `Nothing to save yet.` and writes no file.
+`/save` writes the full transcript — including the system message as its first message, when the session has one — to JSON. With no argument it goes to `.nanotune/chats/<timestamp>.json`, creating the directory if it is missing; `/save runs/terse-bash.json` writes to that path instead, relative to the current directory, creating parent directories. If nothing has been said yet it reports `Nothing to save yet.` and writes no file.
+
+An existing file is never overwritten silently — transcripts are history you can't get back. `/save` refuses and tells you what to do instead:
+
+```
+> /save runs/terse-bash.json
+Could not save: runs/terse-bash.json already exists — use "/save runs/terse-bash.json --force" to overwrite it.
+```
+
+Add `--force` (or `-f`) to overwrite deliberately.
 
 The saved file is an array holding a single object with a `messages` array:
 

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -6,7 +6,9 @@ import {Header, useKeyInput} from '../components/index.js';
 import {
 	buildGenerateOptions,
 	buildServerOptions,
+	lastExchange,
 	parseSlashCommand,
+	saveTranscript,
 } from '../lib/chat-helpers.js';
 import {
 	configExists,
@@ -14,6 +16,7 @@ import {
 	loadConfig,
 	resolveContextMessage,
 } from '../lib/config.js';
+import {appendToTrainingData, countExamples} from '../lib/data.js';
 import {
 	chatCompletion,
 	type ServerHandle,
@@ -59,6 +62,8 @@ const HELP_TEXT = [
 	'  /help          Show this help',
 	'  /reset         Clear conversation history',
 	'  /system <txt>  Replace the system message and reset history',
+	'  /save [file]   Save the transcript to a JSON file',
+	'  /keep          Append the last exchange to train.jsonl',
 	'  /stats         Show session token statistics',
 	'  /exit, /quit   Leave the chat',
 ].join('\n');
@@ -291,6 +296,45 @@ export function ChatCommand({options}: Props) {
 						content: 'Usage: /system <new system message>',
 					});
 					return;
+				case 'save': {
+					if (history.length === 0) {
+						appendTurn({role: 'info', content: 'Nothing to save yet.'});
+						return;
+					}
+					try {
+						const path = saveTranscript(systemMessage, history, cmd.path);
+						appendTurn({role: 'info', content: `Transcript saved to ${path}`});
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : 'Write failed';
+						appendTurn({role: 'info', content: `Could not save: ${msg}`});
+					}
+					return;
+				}
+				case 'keep': {
+					const exchange = lastExchange(history);
+					if (!exchange) {
+						appendTurn({role: 'info', content: 'Nothing to keep yet.'});
+						return;
+					}
+					if (!systemMessage?.content) {
+						appendTurn({
+							role: 'info',
+							content: 'No system message set. Use /system <text> first.',
+						});
+						return;
+					}
+					try {
+						appendToTrainingData({contextMessage: systemMessage, ...exchange});
+						appendTurn({
+							role: 'info',
+							content: `Kept last exchange (${countExamples()} examples total).`,
+						});
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : 'Write failed';
+						appendTurn({role: 'info', content: `Could not keep: ${msg}`});
+					}
+					return;
+				}
 				case 'stats':
 					appendTurn({
 						role: 'info',
@@ -311,7 +355,7 @@ export function ChatCommand({options}: Props) {
 					return;
 			}
 		},
-		[appendTurn, exit, history.length, sendMessage, systemMessage, totalTokens],
+		[appendTurn, exit, history, sendMessage, systemMessage, totalTokens],
 	);
 
 	useKeyInput((_input, key) => {

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -62,7 +62,7 @@ const HELP_TEXT = [
 	'  /help          Show this help',
 	'  /reset         Clear conversation history',
 	'  /system <txt>  Replace the system message and reset history',
-	'  /save [file]   Save the transcript to a JSON file',
+	'  /save [file]   Save the transcript to JSON (--force overwrites)',
 	'  /keep          Append the last exchange to train.jsonl',
 	'  /stats         Show session token statistics',
 	'  /exit, /quit   Leave the chat',
@@ -302,7 +302,12 @@ export function ChatCommand({options}: Props) {
 						return;
 					}
 					try {
-						const path = saveTranscript(systemMessage, history, cmd.path);
+						const path = saveTranscript(
+							systemMessage,
+							history,
+							cmd.path,
+							cmd.force,
+						);
 						appendTurn({role: 'info', content: `Transcript saved to ${path}`});
 					} catch (err) {
 						const msg = err instanceof Error ? err.message : 'Write failed';
@@ -314,13 +319,6 @@ export function ChatCommand({options}: Props) {
 					const exchange = lastExchange(history);
 					if (!exchange) {
 						appendTurn({role: 'info', content: 'Nothing to keep yet.'});
-						return;
-					}
-					if (!systemMessage?.content) {
-						appendTurn({
-							role: 'info',
-							content: 'No system message set. Use /system <text> first.',
-						});
 						return;
 					}
 					try {

--- a/src/lib/chat-helpers.spec.ts
+++ b/src/lib/chat-helpers.spec.ts
@@ -1,9 +1,15 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import test from "ava";
+import type { ChatMessage } from "../types/index.js";
 import {
 	buildGenerateOptions,
 	buildServerOptions,
+	lastExchange,
 	parseSlashCommand,
+	saveTranscript,
 } from "./chat-helpers.js";
+import { importData, loadTrainingData } from "./data.js";
 
 // ── parseSlashCommand ─────────────────────────────────────────────────
 
@@ -211,4 +217,222 @@ test("buildGenerateOptions: explicit --max-tokens overrides preset value", (t) =
 test("buildGenerateOptions: unknown preset falls back to the 256 default", (t) => {
 	const result = buildGenerateOptions({ preset: "nonexistent" });
 	t.is(result.maxTokens, 256);
+});
+
+test("parseSlashCommand recognises /save without an argument", (t) => {
+	t.deepEqual(parseSlashCommand("/save"), { kind: "save" });
+});
+
+test("parseSlashCommand recognises /save with a path argument", (t) => {
+	t.deepEqual(parseSlashCommand("/save runs/session.json"), {
+		kind: "save",
+		path: "runs/session.json",
+	});
+});
+
+test("parseSlashCommand /save with only whitespace after it takes no path", (t) => {
+	t.deepEqual(parseSlashCommand("/save    "), { kind: "save" });
+});
+
+test("parseSlashCommand /save preserves case of the path", (t) => {
+	t.deepEqual(parseSlashCommand("/save My-Chat.JSON"), {
+		kind: "save",
+		path: "My-Chat.JSON",
+	});
+});
+
+test("parseSlashCommand recognises /keep", (t) => {
+	t.deepEqual(parseSlashCommand("/keep"), { kind: "keep" });
+});
+
+test("parseSlashCommand /keep ignores trailing arguments", (t) => {
+	t.deepEqual(parseSlashCommand("/keep this one"), { kind: "keep" });
+});
+
+test("parseSlashCommand is case-insensitive for /save and /keep", (t) => {
+	t.deepEqual(parseSlashCommand("/SAVE"), { kind: "save" });
+	t.deepEqual(parseSlashCommand("/Keep"), { kind: "keep" });
+});
+
+// ── lastExchange ──────────────────────────────────────────────────────
+
+test("lastExchange returns null for an empty history", (t) => {
+	t.is(lastExchange([]), null);
+});
+
+test("lastExchange returns null when the model has not replied yet", (t) => {
+	t.is(lastExchange([{ role: "user", content: "hello" }]), null);
+});
+
+test("lastExchange returns the only exchange", (t) => {
+	t.deepEqual(
+		lastExchange([
+			{ role: "user", content: "hello" },
+			{ role: "assistant", content: "hi" },
+		]),
+		{ userInput: "hello", assistantOutput: "hi" },
+	);
+});
+
+test("lastExchange returns the most recent exchange in a long chat", (t) => {
+	t.deepEqual(
+		lastExchange([
+			{ role: "user", content: "first" },
+			{ role: "assistant", content: "one" },
+			{ role: "user", content: "second" },
+			{ role: "assistant", content: "two" },
+			{ role: "user", content: "third" },
+			{ role: "assistant", content: "three" },
+		]),
+		{ userInput: "third", assistantOutput: "three" },
+	);
+});
+
+test("lastExchange ignores a trailing user turn still awaiting a reply", (t) => {
+	t.deepEqual(
+		lastExchange([
+			{ role: "user", content: "first" },
+			{ role: "assistant", content: "one" },
+			{ role: "user", content: "pending" },
+		]),
+		{ userInput: "first", assistantOutput: "one" },
+	);
+});
+
+test("lastExchange returns null when an assistant turn has no user before it", (t) => {
+	t.is(lastExchange([{ role: "assistant", content: "unprompted" }]), null);
+});
+
+// ── saveTranscript ────────────────────────────────────────────────────
+
+const SYSTEM: ChatMessage = { role: "system", content: "You are terse." };
+const HISTORY: ChatMessage[] = [
+	{ role: "user", content: "list files by size" },
+	{ role: "assistant", content: "ls -lS" },
+];
+
+const ORIG_CWD = process.cwd();
+const TMP_ROOT = join(ORIG_CWD, ".test-chat-helpers");
+
+function inProject(name: string, fn: (dir: string) => void): void {
+	const dir = join(TMP_ROOT, name);
+	rmSync(dir, { recursive: true, force: true });
+	mkdirSync(dir, { recursive: true });
+	process.chdir(dir);
+	try {
+		fn(dir);
+	} finally {
+		process.chdir(ORIG_CWD);
+	}
+}
+
+function readTranscript(path: string): Array<{ messages: ChatMessage[] }> {
+	return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+test.after.always(() => {
+	process.chdir(ORIG_CWD);
+	rmSync(TMP_ROOT, { recursive: true, force: true });
+});
+
+test.serial("saveTranscript defaults to a timestamped file in .nanotune/chats", (t) => {
+	inProject("default-path", (dir) => {
+		const path = saveTranscript(SYSTEM, HISTORY);
+		t.is(dirname(path), join(dir, ".nanotune", "chats"));
+		t.regex(basename(path), /^\d{4}-\d{2}-\d{2}T[\d-]+Z\.json$/);
+		t.true(existsSync(path));
+	});
+});
+
+test.serial("saveTranscript writes the system message ahead of the history", (t) => {
+	inProject("with-system", () => {
+		const saved = readTranscript(saveTranscript(SYSTEM, HISTORY));
+		t.is(saved.length, 1);
+		t.deepEqual(saved[0].messages, [SYSTEM, ...HISTORY]);
+	});
+});
+
+test.serial("saveTranscript omits the system message when there is none", (t) => {
+	inProject("no-system", () => {
+		const saved = readTranscript(saveTranscript(null, HISTORY));
+		t.deepEqual(saved[0].messages, HISTORY);
+	});
+});
+
+test.serial("saveTranscript omits an empty system message", (t) => {
+	inProject("empty-system", () => {
+		const saved = readTranscript(
+			saveTranscript({ role: "system", content: "" }, HISTORY),
+		);
+		t.deepEqual(saved[0].messages, HISTORY);
+	});
+});
+
+test.serial("saveTranscript keeps a non-system context role", (t) => {
+	inProject("developer-role", () => {
+		const ctx: ChatMessage = { role: "developer", content: "Be terse." };
+		const saved = readTranscript(saveTranscript(ctx, HISTORY));
+		t.is(saved[0].messages[0].role, "developer");
+	});
+});
+
+test.serial("saveTranscript writes to an explicit path", (t) => {
+	inProject("explicit-path", (dir) => {
+		const path = saveTranscript(SYSTEM, HISTORY, "session.json");
+		t.is(path, "session.json");
+		t.true(existsSync(join(dir, "session.json")));
+	});
+});
+
+test.serial("saveTranscript creates missing parent directories", (t) => {
+	inProject("nested-path", (dir) => {
+		const path = saveTranscript(SYSTEM, HISTORY, join("runs", "a", "b.json"));
+		t.true(existsSync(join(dir, "runs", "a", "b.json")));
+		t.is(readTranscript(path)[0].messages.length, 3);
+	});
+});
+
+test.serial("saveTranscript keeps every turn of a multi-turn conversation", (t) => {
+	inProject("multi-turn", () => {
+		const history: ChatMessage[] = [
+			{ role: "user", content: "one" },
+			{ role: "assistant", content: "1" },
+			{ role: "user", content: "two" },
+			{ role: "assistant", content: "2" },
+		];
+		const saved = readTranscript(saveTranscript(SYSTEM, history));
+		t.is(saved[0].messages.length, 5);
+		t.is(saved[0].messages[4].content, "2");
+	});
+});
+
+test.serial("saveTranscript output is importable by nanotune data import", (t) => {
+	inProject("importable", () => {
+		mkdirSync(join(".nanotune", "data"), { recursive: true });
+		const path = saveTranscript(SYSTEM, HISTORY);
+		const result = importData(path, { role: "system", content: "ignored" });
+		t.deepEqual(result.errors, []);
+		t.is(result.imported, 1);
+		t.is(result.skipped, 0);
+		const imported = loadTrainingData();
+		t.is(imported.length, 1);
+		t.deepEqual(imported[0].messages, [SYSTEM, ...HISTORY]);
+	});
+});
+
+test.serial("saveTranscript overwrites an existing file at the same path", (t) => {
+	inProject("overwrite", () => {
+		saveTranscript(SYSTEM, HISTORY, "session.json");
+		const saved = readTranscript(
+			saveTranscript(SYSTEM, [{ role: "user", content: "only" }], "session.json"),
+		);
+		t.is(saved[0].messages.length, 2);
+	});
+});
+
+test.serial("saveTranscript ends the file with a newline", (t) => {
+	inProject("trailing-newline", () => {
+		const path = saveTranscript(SYSTEM, HISTORY, "session.json");
+		t.true(readFileSync(path, "utf-8").endsWith("}\n]\n"));
+	});
 });

--- a/src/lib/chat-helpers.spec.ts
+++ b/src/lib/chat-helpers.spec.ts
@@ -241,6 +241,23 @@ test("parseSlashCommand /save preserves case of the path", (t) => {
 	});
 });
 
+test("parseSlashCommand recognises --force on /save", (t) => {
+	t.deepEqual(parseSlashCommand("/save runs/session.json --force"), {
+		kind: "save",
+		path: "runs/session.json",
+		force: true,
+	});
+	t.deepEqual(parseSlashCommand("/save -f session.json"), {
+		kind: "save",
+		path: "session.json",
+		force: true,
+	});
+});
+
+test("parseSlashCommand /save --force alone takes no path", (t) => {
+	t.deepEqual(parseSlashCommand("/save --force"), { kind: "save", force: true });
+});
+
 test("parseSlashCommand recognises /keep", (t) => {
 	t.deepEqual(parseSlashCommand("/keep"), { kind: "keep" });
 });
@@ -420,11 +437,27 @@ test.serial("saveTranscript output is importable by nanotune data import", (t) =
 	});
 });
 
-test.serial("saveTranscript overwrites an existing file at the same path", (t) => {
-	inProject("overwrite", () => {
+test.serial("saveTranscript refuses to overwrite an existing file", (t) => {
+	inProject("no-clobber", () => {
+		const path = saveTranscript(SYSTEM, HISTORY, "session.json");
+		const err = t.throws(() =>
+			saveTranscript(SYSTEM, [{ role: "user", content: "only" }], "session.json"),
+		);
+		t.regex(err?.message ?? "", /already exists/);
+		t.deepEqual(readTranscript(path)[0].messages, [SYSTEM, ...HISTORY]);
+	});
+});
+
+test.serial("saveTranscript overwrites an existing file when forced", (t) => {
+	inProject("overwrite-forced", () => {
 		saveTranscript(SYSTEM, HISTORY, "session.json");
 		const saved = readTranscript(
-			saveTranscript(SYSTEM, [{ role: "user", content: "only" }], "session.json"),
+			saveTranscript(
+				SYSTEM,
+				[{ role: "user", content: "only" }],
+				"session.json",
+				true,
+			),
 		);
 		t.is(saved[0].messages.length, 2);
 	});

--- a/src/lib/chat-helpers.ts
+++ b/src/lib/chat-helpers.ts
@@ -1,4 +1,4 @@
-import {mkdirSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {
 	BENCHMARK_PRESETS,
@@ -83,7 +83,7 @@ export type SlashCommand =
 	| {kind: 'stats'}
 	| {kind: 'system'; text: string}
 	| {kind: 'system-missing'}
-	| {kind: 'save'; path?: string}
+	| {kind: 'save'; path?: string; force?: true}
 	| {kind: 'keep'}
 	| {kind: 'unknown'; name: string}
 	| {kind: 'noop'};
@@ -122,8 +122,17 @@ export function parseSlashCommand(input: string): SlashCommand {
 			return {kind: 'stats'};
 		case '/system':
 			return arg ? {kind: 'system', text: arg} : {kind: 'system-missing'};
-		case '/save':
-			return arg ? {kind: 'save', path: arg} : {kind: 'save'};
+		case '/save': {
+			const isForce = (part: string) => part === '--force' || part === '-f';
+			const path = rest
+				.filter(part => !isForce(part))
+				.join(' ')
+				.trim();
+			const cmd = path
+				? ({kind: 'save', path} as const)
+				: ({kind: 'save'} as const);
+			return rest.some(isForce) ? {...cmd, force: true} : cmd;
+		}
 		case '/keep':
 			return {kind: 'keep'};
 		default:
@@ -151,16 +160,27 @@ export function lastExchange(
 	return null;
 }
 
+/**
+ * Write the session transcript as JSON. Refuses to clobber an existing file
+ * unless `force` is set — a transcript is history you can't get back once it
+ * is gone.
+ */
 export function saveTranscript(
 	systemMessage: ChatMessage | null,
 	history: ChatMessage[],
 	filePath?: string,
+	force = false,
 ): string {
 	const messages = systemMessage?.content
 		? [systemMessage, ...history]
 		: history;
 	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
 	const path = filePath ?? join(getChatsDir(), `${stamp}.json`);
+	if (!force && existsSync(path)) {
+		throw new Error(
+			`${path} already exists — use "/save ${path} --force" to overwrite it.`,
+		);
+	}
 	mkdirSync(dirname(path), {recursive: true});
 	writeFileSync(path, `${JSON.stringify([{messages}], null, 2)}\n`);
 	return path;

--- a/src/lib/chat-helpers.ts
+++ b/src/lib/chat-helpers.ts
@@ -1,4 +1,11 @@
-import {BENCHMARK_PRESETS, type BenchmarkPreset} from '../types/index.js';
+import {mkdirSync, writeFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {
+	BENCHMARK_PRESETS,
+	type BenchmarkPreset,
+	type ChatMessage,
+} from '../types/index.js';
+import {getChatsDir} from './config.js';
 import type {GenerateOptions, ServerOptions} from './llama-cpp.js';
 
 /** Raw option strings that come off commander; everything is a string until we
@@ -76,6 +83,8 @@ export type SlashCommand =
 	| {kind: 'stats'}
 	| {kind: 'system'; text: string}
 	| {kind: 'system-missing'}
+	| {kind: 'save'; path?: string}
+	| {kind: 'keep'}
 	| {kind: 'unknown'; name: string}
 	| {kind: 'noop'};
 
@@ -113,7 +122,46 @@ export function parseSlashCommand(input: string): SlashCommand {
 			return {kind: 'stats'};
 		case '/system':
 			return arg ? {kind: 'system', text: arg} : {kind: 'system-missing'};
+		case '/save':
+			return arg ? {kind: 'save', path: arg} : {kind: 'save'};
+		case '/keep':
+			return {kind: 'keep'};
 		default:
 			return {kind: 'unknown', name: rawCmd};
 	}
+}
+
+export function lastExchange(
+	history: ChatMessage[],
+): {userInput: string; assistantOutput: string} | null {
+	for (let i = history.length - 1; i >= 0; i--) {
+		if (history[i].role !== 'assistant') {
+			continue;
+		}
+		for (let j = i - 1; j >= 0; j--) {
+			if (history[j].role === 'user') {
+				return {
+					userInput: history[j].content,
+					assistantOutput: history[i].content,
+				};
+			}
+		}
+		return null;
+	}
+	return null;
+}
+
+export function saveTranscript(
+	systemMessage: ChatMessage | null,
+	history: ChatMessage[],
+	filePath?: string,
+): string {
+	const messages = systemMessage?.content
+		? [systemMessage, ...history]
+		: history;
+	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+	const path = filePath ?? join(getChatsDir(), `${stamp}.json`);
+	mkdirSync(dirname(path), {recursive: true});
+	writeFileSync(path, `${JSON.stringify([{messages}], null, 2)}\n`);
+	return path;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,6 +36,10 @@ export function getBenchmarksDir(): string {
 	return join(getProjectDir(), 'benchmarks');
 }
 
+export function getChatsDir(): string {
+	return join(getProjectDir(), 'chats');
+}
+
 export function configExists(): boolean {
 	return existsSync(getConfigPath());
 }
@@ -62,6 +66,7 @@ const GITIGNORE_CONTENTS = `# Nanotune project artifacts
 adapters/
 models/
 benchmarks/
+chats/
 judge.json
 `;
 

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -87,6 +87,39 @@ test.serial("appendToTrainingData writes to eval file when isEval is true", (t) 
   t.is(countExamples(true), 1);
 });
 
+test.serial("appendToTrainingData omits the context message when there is none", (t) => {
+  appendToTrainingData({ userInput: "Hello", assistantOutput: "Hi there!" });
+
+  const data = loadTrainingData();
+  t.is(data.length, 1);
+  t.deepEqual(data[0].messages, [
+    { role: "user", content: "Hello" },
+    { role: "assistant", content: "Hi there!" },
+  ]);
+});
+
+test.serial("appendToTrainingData omits a null or empty context message", (t) => {
+  appendToTrainingData({ contextMessage: null, userInput: "A", assistantOutput: "B" });
+  appendToTrainingData({
+    contextMessage: { role: "system", content: "" },
+    userInput: "C",
+    assistantOutput: "D",
+  });
+
+  const data = loadTrainingData();
+  t.is(data.length, 2);
+  t.deepEqual(data[0].messages.map((m) => m.role), ["user", "assistant"]);
+  t.deepEqual(data[1].messages.map((m) => m.role), ["user", "assistant"]);
+});
+
+test.serial("an example with no context message still validates", (t) => {
+  appendToTrainingData({ userInput: "Hello", assistantOutput: "Hi there!" });
+
+  const result = validateTrainingData(SYSTEM_CTX);
+  t.deepEqual(result.errors, []);
+  t.true(result.valid);
+});
+
 // ── updateExample ─────────────────────────────────────────────────────
 
 test.serial("updateExample replaces an existing example", (t) => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -66,18 +66,20 @@ export function appendTrainingExample(
 
 export function appendToTrainingData(
 	example: {
-		contextMessage: ChatMessage;
+		/** Omitted, or empty, when the session has no system message — the
+		 *  example is then just the user/assistant pair. */
+		contextMessage?: ChatMessage | null;
 		userInput: string;
 		assistantOutput: string;
 	},
 	isEval = false,
 ): void {
+	const {contextMessage} = example;
 	const trainingExample: TrainingExample = {
 		messages: [
-			{
-				role: example.contextMessage.role,
-				content: example.contextMessage.content,
-			},
+			...(contextMessage?.content
+				? [{role: contextMessage.role, content: contextMessage.content}]
+				: []),
 			{role: 'user', content: example.userInput},
 			{role: 'assistant', content: example.assistantOutput},
 		],


### PR DESCRIPTION
Closes #74

## Description

Adds `/save` and `/keep` to the `nanotune chat` REPL so a session can be kept instead of lost on exit.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully) 
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [x] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)