### PR TITLE
docs: explain why judge.json needs both mode and chmod

### DIFF
--- a/src/lib/judge.ts
+++ b/src/lib/judge.ts
@@ -59,13 +59,21 @@ export function loadJudgeConfig(): JudgeProviderConfig {
 	return substituteEnvVars(raw);
 }
 
+/**
+ * Write judge.json at 0600 — `apiKey` may hold a literal secret, not just the
+ * `${ENV_VAR}` form.
+ *
+ * The two 0600s below are not duplicates: each covers a case the other cannot.
+ * Drop the `mode` and a fresh config is created 0644, receives the key, and is
+ * tightened only afterwards — too late for a process that already opened it,
+ * since chmod cannot revoke an open descriptor.
+ */
 export function saveJudgeConfig(config: JudgeProviderConfig): void {
 	const path = getJudgeConfigPath();
-	// 0600 — this file can hold a literal API key (users who don't use the
-	// ${ENV_VAR} form), so keep it readable only by its owner.
+	// New file: open(2) honours `mode` only when it creates the file.
 	writeFileSync(path, JSON.stringify(config, null, 2), {mode: 0o600});
-	// writeFileSync only applies `mode` when it creates the file, so re-chmod
-	// to also fix up configs written by earlier versions.
+	// Existing file: open(2) ignored `mode` above. Also repairs the 0644
+	// configs written by 1.5.0 and earlier.
 	chmodSync(path, 0o600);
 }
 


### PR DESCRIPTION
## Description

Closes #86.

The issue offered two options: delete `{mode: 0o600}`, **or** comment on why it's kept. This takes the second — the first would regress security.

`mode` is passed to `open(2)`, which applies it **only when creating** a file and ignores it otherwise. So the two calls cover disjoint cases:

| | `{mode: 0o600}` | `chmodSync` |
|---|---|---|
| **New** `judge.json` | creates it `0600` | redundant |
| **Existing** `0644` file | ignored by `open(2)` | does the work |

Measured, Node 26, `umask 022`:

```
new file, WITH mode 0600  -> 600
new file, WITHOUT mode    -> 644   <- world-readable
existing 0644, WITH mode  -> 644   <- mode silently ignored
```

`chmodSync` is needed because `saveJudgeConfig` in ≤1.5.0 was a bare `writeFileSync` with no mode (`git show 0c3266b~1`), leaving `judge.json` at `0644`.

**Why deleting the mode would regress:** `apiKey` may hold a literal secret. Without the mode, every `judge configure` creates the file `0644`, writes the key, then tightens it. That's too late — `chmod` does not revoke an already-open descriptor:

```
mode at creation : 644
mode after chmod : 600
read from old fd : "{\"apiKey\":\"sk-LEAKED-SECRET\"}"
```

An attacker wins that race once and keeps a permanent read handle.

## Type of Change

- [x] Documentation update (comments only — no logic change)

## Testing

- [x] Existing tests pass — 239, unchanged
- [ ] New tests added — **not possible here**

A test cannot detect removal of `{mode: 0o600}`: the trailing unconditional `chmodSync` forces `0600` either way, so both existing permission tests pass with or without it. That untestability is exactly why the line reads as redundant, and why this PR invests in comments.

Ran `format`, `test:lint`, `test:types`, `test:ava` — all clean. Not `test:all`: `test:security` needs semgrep, which I don't have locally. CI covers it.

Manual testing N/A — no executable code changed, and no templated command reaches `saveJudgeConfig`.

## Checklist

- [x] `pnpm format`
- [x] Self-review completed
- [x] No breaking changes

## Follow-up (not in this PR)

Filed separately as #100: on the legacy path the key is written into the existing `0644` file *before* the `chmod`, and `chmod` can't revoke an already-open descriptor. The fix there (temp file + `flag: 'wx'` + `rename()`) also makes the write atomic and lets `chmodSync` go entirely — which finally makes the safeguard testable.

Kept out of this PR deliberately: it changes behaviour in a secret-handling path and deserves its own review.
