### PR TITLE
fix: write judge.json atomically instead of tightening it after

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -67,7 +67,7 @@ adapters/
 models/
 benchmarks/
 chats/
-judge.json
+judge.json*
 `;
 
 export function initializeProjectDirs(): void {

--- a/src/lib/judge.spec.ts
+++ b/src/lib/judge.spec.ts
@@ -1,4 +1,12 @@
-import {mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync} from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
@@ -247,6 +255,80 @@ test.serial('saveJudgeConfig - tightens permissions on a pre-existing file', t =
 		});
 
 		t.is(statSync(path).mode & 0o777, 0o600);
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('saveJudgeConfig - is 0600 even under a permissive umask', t => {
+	const originalCwd = process.cwd();
+	// umask 0 is the only setting under which a dropped `mode` becomes visible
+	// in the finished file: without it the temp is created 0666 and rename
+	// carries that straight onto judge.json.
+	const originalUmask = process.umask(0o000);
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		mkdirSync(join(dir, '.nanotune'), {recursive: true});
+
+		saveJudgeConfig({
+			name: 'Test',
+			baseUrl: 'https://example.invalid/v1',
+			apiKey: 'sk-secret',
+			model: 'test-model',
+		});
+
+		t.is(statSync(getJudgeConfigPath()).mode & 0o777, 0o600);
+	} finally {
+		process.chdir(originalCwd);
+		process.umask(originalUmask);
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('saveJudgeConfig - leaves no temp file behind', t => {
+	const originalCwd = process.cwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		mkdirSync(join(dir, '.nanotune'), {recursive: true});
+
+		saveJudgeConfig({
+			name: 'Test',
+			baseUrl: 'https://example.invalid/v1',
+			model: 'test-model',
+		});
+
+		t.false(existsSync(`${getJudgeConfigPath()}.tmp`));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('saveJudgeConfig - recovers from a stale temp file', t => {
+	const originalCwd = process.cwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		mkdirSync(join(dir, '.nanotune'), {recursive: true});
+
+		// A process killed between write and rename leaves this behind. The
+		// exclusive create would fail with EEXIST forever if it were not
+		// cleared first.
+		const path = join(dir, '.nanotune', 'judge.json');
+		writeFileSync(`${path}.tmp`, '{"stale":true}', {mode: 0o600});
+
+		t.notThrows(() =>
+			saveJudgeConfig({
+				name: 'Test',
+				baseUrl: 'https://example.invalid/v1',
+				model: 'test-model',
+			}),
+		);
+		t.is(statSync(path).mode & 0o777, 0o600);
+		t.is(JSON.parse(readFileSync(path, 'utf-8')).name, 'Test');
 	} finally {
 		process.chdir(originalCwd);
 		rmSync(dir, {recursive: true, force: true});

--- a/src/lib/judge.ts
+++ b/src/lib/judge.ts
@@ -1,4 +1,10 @@
-import {chmodSync, existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {
+	existsSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import {join} from 'node:path';
 import {createAnthropic} from '@ai-sdk/anthropic';
 import {createGoogleGenerativeAI} from '@ai-sdk/google';
@@ -63,18 +69,28 @@ export function loadJudgeConfig(): JudgeProviderConfig {
  * Write judge.json at 0600 — `apiKey` may hold a literal secret, not just the
  * `${ENV_VAR}` form.
  *
- * The two 0600s below are not duplicates: each covers a case the other cannot.
- * Drop the `mode` and a fresh config is created 0644, receives the key, and is
- * tightened only afterwards — too late for a process that already opened it,
- * since chmod cannot revoke an open descriptor.
+ * Writes a temp file and renames it over the target rather than writing in
+ * place. rename(2) is atomic and carries the mode with it, so the key is never
+ * present in a file that is not already 0600 — including when replacing a 0644
+ * config left by 1.5.0 or earlier — and an interrupted write cannot leave a
+ * truncated judge.json for `loadJudgeConfig` to choke on.
  */
 export function saveJudgeConfig(config: JudgeProviderConfig): void {
 	const path = getJudgeConfigPath();
-	// New file: open(2) honours `mode` only when it creates the file.
-	writeFileSync(path, JSON.stringify(config, null, 2), {mode: 0o600});
-	// Existing file: open(2) ignored `mode` above. Also repairs the 0644
-	// configs written by 1.5.0 and earlier.
-	chmodSync(path, 0o600);
+	const tmp = `${path}.tmp`;
+	// Clear a temp left behind by a process that died between write and
+	// rename. Without this the `wx` below would fail with EEXIST on every
+	// subsequent save.
+	rmSync(tmp, {force: true});
+	// `wx` is O_CREAT|O_EXCL: it guarantees a brand new inode, which is what
+	// makes open(2) honour `mode` — it ignores mode for a file that already
+	// exists. It also means we fail outright rather than write the key into a
+	// file someone else put there.
+	writeFileSync(tmp, JSON.stringify(config, null, 2), {
+		mode: 0o600,
+		flag: 'wx',
+	});
+	renameSync(tmp, path);
 }
 
 /** Resolve criteria names to full JudgeCriteria objects */


### PR DESCRIPTION
## Description

Closes #100. Follow-up to #99, which documented why `saveJudgeConfig` needed both `{mode: 0o600}` and `chmodSync` but deliberately left the behaviour alone.

`open(2)` ignores `mode` for a file that already exists, so on the legacy path — a `judge.json` written by ≤1.5.0, which passed no mode at all and left it `0644` — the API key was written into the `0644` file and tightened only afterwards. `chmod` does not revoke a descriptor another process already holds open.

This writes a temp file and renames it over the target:

```ts
const tmp = `${path}.tmp`;
rmSync(tmp, {force: true});
writeFileSync(tmp, JSON.stringify(config, null, 2), {mode: 0o600, flag: 'wx'});
renameSync(tmp, path);
```

`wx` (`O_CREAT|O_EXCL`) guarantees a fresh inode, which is what makes `open(2)` honour the mode, and means we fail rather than write the key into a file someone else created. `rename(2)` is atomic and carries the mode across. `chmodSync` is no longer reachable and is removed — which is what #86 was originally reaching for.

## What else falls out of it

**The write is atomic.** `loadJudgeConfig` does `JSON.parse(readFileSync(...))` with no guard, so an interrupted `writeFileSync` (ENOSPC, Ctrl-C, power loss) previously left a truncated `judge.json` and the next run threw a raw `SyntaxError`. That's now impossible.

**The safeguard became testable — this is the main win.** Previously the trailing unconditional `chmodSync` forced `0600` whether or not `{mode: 0o600}` was present, so no assertion could detect its removal. That's precisely why the line read as redundant and #86 got filed. Deleting `mode` on this branch now fails **four** tests:

```
✘ saveJudgeConfig - writes judge.json with 0600 permissions
✘ saveJudgeConfig - tightens permissions on a pre-existing file
✘ saveJudgeConfig - is 0600 even under a permissive umask
✘ saveJudgeConfig - recovers from a stale temp file
```

Note the first two are the *existing* tests — they become load-bearing under this change, where before they passed either way.

## Failure handling

A temp left by a process killed between write and rename is cleared on the next save; without the `rmSync` the exclusive create would fail with `EEXIST` from then on. There's a test for that. The `.gitignore` written into new projects now covers `judge.json*`, so a stray temp holding a key can't be committed.

## Type of Change

- [x] Bug fix

## Testing

- [x] All existing tests pass — **312 passing** (3 new)
- [x] New tests added

Three added: `0600` under a permissive umask (the regression guard — `umask 0` is the only setting where a dropped `mode` shows up in the finished file), no temp left behind, and recovery from a stale temp.

Ran `format`, `test:lint` (on changed files), `test:types`, `test:ava` — all clean. `test:all` not run end to end: `test:security` needs semgrep, which I don't have locally.

Manual testing N/A — `saveJudgeConfig` is covered directly by the five permission tests, and none of the templated commands reach it.

## Heads-up: `main` currently fails `pnpm test:lint`

Unrelated to this PR, but it will make CI look red. On a clean `upstream/main`, `biome check` reports 5 errors in `src/cli.tsx`, `src/commands/data/list.tsx`, `src/commands/data/validate.tsx` and `src/lib/data.ts` — none of which this PR touches. `pnpm format` fixes them all; I deliberately left those files alone to keep this diff focused. Happy to open a separate formatting PR if that's useful.

## Checklist

- [x] `pnpm format`
- [x] Self-review completed
- [x] No breaking changes — `judge.json` ends up `0600` exactly as before; only the path there changed
