### PR TITLE
fix(llama-cpp): stop an unhandled ExecaError from killing the CLI

### DIFF
--- a/src/commands/benchmark.tsx
+++ b/src/commands/benchmark.tsx
@@ -245,6 +245,7 @@ export function BenchmarkCommand({options}: Props) {
 	const [currentTest, setCurrentTest] = useState<string | null>(null);
 	const [progress, setProgress] = useState(0);
 	const [results, setResults] = useState<BenchmarkResult | null>(null);
+	const [warning, setWarning] = useState<string | null>(null);
 	const [categories, setCategories] = useState<Record<string, CategoryResult>>(
 		{},
 	);
@@ -523,8 +524,22 @@ export function BenchmarkCommand({options}: Props) {
 			// would multiply latency by N and cache the model from disk N times.
 			const serverHandle = await startLlamaServer(modelPath, serverOptions);
 
+			// The server can die under us mid-run (OOM, an incompatible GGUF, an
+			// external kill). `exited` settles the moment it does — stop there and
+			// report what we have, rather than letting every remaining test fail to
+			// connect and burying the reason.
+			let serverDied = false;
+			let abortReason: string | null = null;
+			void serverHandle.exited.then(() => {
+				serverDied = true;
+			});
+
 			try {
 				for (let i = 0; i < tests.length; i++) {
+					if (serverDied) {
+						abortReason = `llama-server exited unexpectedly after ${i} of ${tests.length} tests — saving partial results.`;
+						break;
+					}
 					const test = tests[i];
 					setCurrentTest(getTestDisplayPrompt(test));
 					setProgress(((i + 1) / tests.length) * 100);
@@ -661,12 +676,22 @@ export function BenchmarkCommand({options}: Props) {
 				await stopLlamaServer(serverHandle);
 			}
 
+			if (abortReason && allResults.length === 0) {
+				// Nothing ran, so there is no partial report worth writing.
+				setError(abortReason);
+				setStatus('error');
+				return;
+			}
+			setWarning(abortReason);
+
 			// Calculate final results
 			const totalPassed = Object.values(categoryResults).reduce(
 				(sum, c) => sum + c.passed,
 				0,
 			);
-			const totalTests = tests.length;
+			// Not `tests.length` — an aborted run must score against what it
+			// actually ran, or the pass rate reads as a catastrophic regression.
+			const totalTests = allResults.length;
 
 			// Calculate average latency (excluding errors/timeouts)
 			const validLatencies = allResults
@@ -825,6 +850,9 @@ export function BenchmarkCommand({options}: Props) {
 					</Box>
 
 					<Text> </Text>
+					{warning && (
+						<StatusMessage variant="warning">{warning}</StatusMessage>
+					)}
 					<Text>
 						Model: <Text color="cyan">{results.model.split('/').pop()}</Text>
 						{results.isBase && <Text dimColor> (base model, control)</Text>}

--- a/src/lib/llama-cpp.spec.ts
+++ b/src/lib/llama-cpp.spec.ts
@@ -1,14 +1,18 @@
 import test from "ava";
+import { execa } from "execa";
 import type {
 	ChatCompletionResponse,
 	InferenceOptions,
 	InferenceResult,
 } from "./llama-cpp.js";
 import {
+	createServerHandle,
 	exportModel,
 	parseChatCompletionResponse,
 	quantize,
 	scaleProgress,
+	stopLlamaServer,
+	waitForServerOrExit,
 } from "./llama-cpp.js";
 
 test("InferenceOptions structure accepts all valid options", (t) => {
@@ -266,4 +270,124 @@ test("exportModel does not jump to 100% before quantization finishes", async (t)
 	t.is(start.value?.progress, 0);
 	t.is(converting.value?.progress, 25);
 	t.is(scaleProgress(50, 100, undefined), 75);
+});
+
+// ── server lifecycle ──────────────────────────────────────────────────
+
+// llama-server itself is not available in CI, so these stand a plain node
+// child process in for it: the bug is in how the execa promise is handled,
+// not in what the child does.
+const spawnChild = (code: string) =>
+	execa(process.execPath, ["-e", code], {
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+/** Collect anything Node reports as an unhandled rejection while `fn` runs. */
+async function withUnhandledRejections(
+	fn: () => Promise<void>,
+): Promise<unknown[]> {
+	const seen: unknown[] = [];
+	const listener = (reason: unknown) => seen.push(reason);
+	process.on("unhandledRejection", listener);
+	try {
+		await fn();
+		// An unhandled rejection is reported at the end of the tick that created
+		// it, so give the loop a turn before deciding none happened.
+		await new Promise((r) => setTimeout(r, 100));
+	} finally {
+		process.off("unhandledRejection", listener);
+	}
+	return seen;
+}
+
+test("createServerHandle settles `exited` when the child exits non-zero, without an unhandled rejection", async (t) => {
+	// Regression: execa's promise was left orphaned, so a server dying mid-run
+	// killed the whole CLI with a raw ExecaError stack dump.
+	let exitValue: unknown;
+	const rejections = await withUnhandledRejections(async () => {
+		const handle = createServerHandle(
+			1234,
+			spawnChild("setTimeout(() => process.exit(3), 50)"),
+		);
+		exitValue = await handle.exited;
+	});
+
+	t.true(exitValue instanceof Error);
+	t.deepEqual(rejections, []);
+});
+
+test("createServerHandle settles `exited` when the child is killed, without an unhandled rejection", async (t) => {
+	let exitValue: unknown;
+	const rejections = await withUnhandledRejections(async () => {
+		const handle = createServerHandle(
+			1234,
+			spawnChild("setInterval(() => {}, 1000)"),
+		);
+		handle.process.kill("SIGTERM");
+		exitValue = await handle.exited;
+	});
+
+	t.true(exitValue instanceof Error);
+	t.deepEqual(rejections, []);
+});
+
+test("stopLlamaServer terminates a running child and resolves", async (t) => {
+	const handle = createServerHandle(
+		1234,
+		spawnChild("setInterval(() => {}, 1000)"),
+	);
+
+	await stopLlamaServer(handle);
+
+	// execa reports a killed child as an error — proof it is actually gone.
+	t.true((await handle.exited) instanceof Error);
+});
+
+test("stopLlamaServer resolves for a child that already exited on its own", async (t) => {
+	// The mid-run case: the server is long gone by the time the caller's
+	// `finally` runs.
+	const handle = createServerHandle(1234, spawnChild("process.exit(3)"));
+	await handle.exited;
+
+	await stopLlamaServer(handle);
+
+	t.pass();
+});
+
+test("stopLlamaServer escalates past a child that ignores SIGTERM", async (t) => {
+	const handle = createServerHandle(
+		1234,
+		spawnChild(
+			"process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+		),
+	);
+
+	await stopLlamaServer(handle, 100);
+
+	t.true((await handle.exited) instanceof Error);
+});
+
+test("waitForServerOrExit reports the child's exit instead of waiting out the startup timeout", async (t) => {
+	// Nothing ever listens on port 1, so /health can only fail.
+	const handle = createServerHandle(1, spawnChild("process.exit(1)"));
+	const started = Date.now();
+
+	const err = await t.throwsAsync(waitForServerOrExit(1, handle.exited, 2000));
+
+	t.true(err?.message.startsWith("llama-server exited during startup"));
+	t.true(Date.now() - started < 1500);
+});
+
+test("waitForServerOrExit still times out when the child stays up but never answers", async (t) => {
+	const handle = createServerHandle(
+		1,
+		spawnChild("setInterval(() => {}, 1000)"),
+	);
+
+	const err = await t.throwsAsync(waitForServerOrExit(1, handle.exited, 300));
+
+	t.true(err?.message.includes("failed to start within"));
+	await stopLlamaServer(handle);
 });

--- a/src/lib/llama-cpp.ts
+++ b/src/lib/llama-cpp.ts
@@ -421,6 +421,55 @@ export interface GenerateOptions {
 export interface ServerHandle {
 	port: number;
 	process: ResultPromise;
+	/**
+	 * Settles when the child exits — with the `ExecaError` if it was killed or
+	 * exited non-zero, never by rejecting. Callers can watch it to notice a
+	 * server that died under them.
+	 */
+	exited: Promise<unknown>;
+}
+
+/**
+ * Wrap a freshly spawned llama-server child in a `ServerHandle`.
+ *
+ * `exited` is attached here, at spawn time, and never later: execa's promise
+ * rejects whenever the child is killed or exits non-zero, and on Node 22 an
+ * unhandled rejection is fatal. Deferring the handler to `stopLlamaServer` —
+ * minutes or hours away — means a server that dies mid-run takes the whole
+ * CLI down with a raw stack dump.
+ */
+export function createServerHandle(
+	port: number,
+	serverProcess: ResultPromise,
+): ServerHandle {
+	return {
+		port,
+		process: serverProcess,
+		exited: serverProcess.catch((err: unknown) => err),
+	};
+}
+
+/**
+ * Wait for the server to answer /health, giving up early if the child exits
+ * first. Without the race a bad GGUF — which llama-server rejects in
+ * milliseconds — reports a generic timeout a full minute later instead of the
+ * exit that actually happened.
+ */
+export async function waitForServerOrExit(
+	port: number,
+	exited: Promise<unknown>,
+	timeoutMs: number,
+): Promise<void> {
+	await Promise.race([
+		waitForServer(port, timeoutMs),
+		exited.then(value => {
+			throw new Error(
+				`llama-server exited during startup${
+					value instanceof Error ? `: ${value.message}` : ''
+				}`,
+			);
+		}),
+	]);
 }
 
 /**
@@ -485,15 +534,16 @@ export async function startLlamaServer(
 		stdout: 'ignore',
 		stderr: 'ignore',
 	});
+	const handle = createServerHandle(port, serverProcess);
 
 	try {
-		await waitForServer(port, startupTimeoutMs);
+		await waitForServerOrExit(port, handle.exited, startupTimeoutMs);
 	} catch (err) {
 		serverProcess.kill();
 		throw err;
 	}
 
-	return {port, process: serverProcess};
+	return handle;
 }
 
 /**
@@ -505,7 +555,7 @@ export async function stopLlamaServer(
 	handle: ServerHandle,
 	graceMs = 2000,
 ): Promise<void> {
-	const exited = handle.process.catch(() => {});
+	const exited = handle.exited;
 	handle.process.kill('SIGTERM');
 
 	const escalation = new Promise<void>(resolve => {


### PR DESCRIPTION
Closes #114

## Description

`startLlamaServer` returned an execa `ResultPromise` with no rejection handler attached.
The promise rejects on any kill or non-zero exit, and Node 22 treats an unhandled
rejection as fatal so both failure paths in #114 killed the process outright.

The fix moves handler attachment to spawn time and stores the settled result on the
handle, so nothing downstream can be caught without one. `chat` needed no change; it
gets its handle from `startLlamaServer`.

**Behaviour change:** a benchmark run whose server dies now stops at that point and
writes what it has, and the summary is scored against the tests that actually ran
(`allResults.length`, not `tests.length`) so an aborted run doesn't read as a
catastrophic regression. A run that dies before its first test is surfaced as an error
rather than written out as an empty report.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init` 
- [x] Tested `nanotune data` 
- [x] Tested `nanotune train` 
- [x] Tested `nanotune export`
- [x] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)