### PR TITLE
fix: report malformed config.json and train.jsonl instead of crashing the render

### DIFF
--- a/.changeset/report-malformed-json.md
+++ b/.changeset/report-malformed-json.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanotune': patch
+---
+
+`nanotune status`, `nanotune train`, `nanotune export`, `nanotune data validate` and `nanotune data list` no longer crash with a React reconciler stack trace when `config.json` is malformed, and `nanotune data validate` no longer crashes when `train.jsonl` contains a bad line — instead each command reports the file (and line, where applicable) and exits with code 1. Malformed lines in `train.jsonl` are preserved so the mutating helpers never silently delete user data; `--fix`/`--rewrite-context` and edit/delete skip when the data does not fully parse. Thanks to @addyCooks. Closes #126.

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,13 +1,31 @@
 #!/usr/bin/env node
 import {readFileSync} from 'node:fs';
 import {Command} from 'commander';
-import {render} from 'ink';
+import {render as inkRender} from 'ink';
 import type {ReactElement} from 'react';
 import {interactiveRequiredMessage, supportsRawMode} from './lib/tty.js';
 
 const pkg = JSON.parse(
 	readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
 ) as {version: string};
+
+/**
+ * `render`, plus a backstop for anything that throws while rendering. Ink
+ * catches those in its own error boundary and rejects `waitUntilExit()`
+ * rather than letting them reach a process-level handler, and because the
+ * render never completes, the effect that would set a non-zero exit code
+ * never runs — so the command dies with a reconciler trace and still exits 0.
+ */
+function render(
+	node: ReactElement,
+	options?: Parameters<typeof inkRender>[1],
+): void {
+	const instance = inkRender(node, options);
+	instance.waitUntilExit().catch((err: unknown) => {
+		console.error(err instanceof Error ? err.message : String(err));
+		process.exitCode = 1;
+	});
+}
 
 /**
  * Render a command that cannot work without a keyboard (prompts, menus, the

--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -530,6 +530,107 @@ test("streamPreview clips a single very long line by characters", (t) => {
   t.is(text.length, 2000);
 });
 
+// ── malformed JSON is reported, not thrown ───────────────────────────
+//
+// A throw from a render body escapes the command's own try/catch and lands in
+// Ink's error boundary. The render never completes, so useAutoExit never runs
+// and the command dies with a reconciler trace while still exiting 0.
+
+function writeRawConfig(contents: string) {
+  writeFileSync(join(NANOTUNE_DIR, "config.json"), contents);
+}
+
+function writeRawTrain(contents: string) {
+  writeFileSync(join(DATA_DIR, "train.jsonl"), contents);
+}
+
+test.serial("StatusCommand reports a malformed config and exits non-zero", async (t) => {
+  try {
+    setupProject();
+    writeRawConfig('{"name":"v","baseMod');
+    process.exitCode = 0;
+
+    const output = await renderCommand(<StatusCommand />, "not valid JSON");
+    t.true(output.includes("Invalid config.json: not valid JSON"));
+    t.false(output.includes("react_stack_bottom_frame"));
+    t.is(process.exitCode, 1);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("DataValidateCommand reports a malformed config and exits non-zero", async (t) => {
+  try {
+    setupProject();
+    writeRawConfig('{"name":"v","baseMod');
+    process.exitCode = 0;
+
+    const output = await renderCommand(<DataValidateCommand />, "not valid JSON");
+    t.true(output.includes("Invalid config.json: not valid JSON"));
+    t.is(process.exitCode, 1);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("DataValidateCommand reports a malformed example and exits non-zero", async (t) => {
+  try {
+    setupProject();
+    writeRawTrain(
+      JSON.stringify(example("one")) + "\nnot json at all\n" +
+        JSON.stringify(example("two")) + "\n",
+    );
+    process.exitCode = 0;
+
+    // The command whose whole purpose is finding malformed training data has
+    // to survive encountering some.
+    const output = await renderCommand(<DataValidateCommand />, "invalid JSON");
+    t.true(output.includes("Example 2: invalid JSON"));
+    t.false(output.includes("react_stack_bottom_frame"));
+    t.is(process.exitCode, 1);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("DataValidateCommand --fix leaves a malformed file untouched", async (t) => {
+  try {
+    setupProject();
+    const contents =
+      JSON.stringify(example("one")) + "\n" +
+      JSON.stringify(example("one")) + "\nnope\n";
+    writeRawTrain(contents);
+
+    // Dedupe rewrites the whole file, so running it here would silently drop
+    // the line the report is meant to point at.
+    await renderCommand(<DataValidateCommand fix />, "invalid JSON");
+    t.is(readFileSync(join(DATA_DIR, "train.jsonl"), "utf-8"), contents);
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("DataListCommand renders the readable rows and flags the rest", async (t) => {
+  const originalTTY = process.stdin.isTTY;
+  try {
+    setupProject();
+    writeRawTrain(
+      JSON.stringify(example("one")) + "\nnot json at all\n" +
+        JSON.stringify(example("two")) + "\n",
+    );
+    process.stdin.isTTY = true;
+
+    const output = await renderCommand(<DataListCommand />, "unreadable line");
+    t.true(output.includes("one"));
+    t.true(output.includes("two"));
+    t.true(output.includes("1 unreadable line"));
+    t.false(output.includes("react_stack_bottom_frame"));
+  } finally {
+    process.stdin.isTTY = originalTTY;
+    teardown();
+  }
+});
+
 // ── data list edits the set it was opened on ──────────────────────────
 
 test.serial(

--- a/src/commands/data/list.tsx
+++ b/src/commands/data/list.tsx
@@ -9,6 +9,7 @@ import {
 	countTurns,
 	deleteExample,
 	loadTrainingData,
+	parseTrainingData,
 	mergeEditedTurn,
 	updateTrainingExample,
 } from '../../lib/data.js';
@@ -27,7 +28,10 @@ export function DataListCommand({isEval = false}: Props) {
 	const [page, setPage] = useState(0);
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-	const [data, setData] = useState(() => loadTrainingData(isEval));
+	// Parse without throwing so a malformed line renders the rest of the set
+	// instead of taking the whole command down during the first render.
+	const [parsed] = useState(() => parseTrainingData(isEval));
+	const [data, setData] = useState(parsed.examples);
 	const [otherCount] = useState(() => countExamples(!isEval));
 	const [message, setMessage] = useState<{
 		type: 'success' | 'error';
@@ -289,6 +293,14 @@ export function DataListCommand({isEval = false}: Props) {
 			{message && (
 				<Box marginBottom={1}>
 					<StatusMessage variant={message.type}>{message.text}</StatusMessage>
+				</Box>
+			)}
+
+			{parsed.errors.length > 0 && (
+				<Box marginBottom={1}>
+					<StatusMessage variant="warning">
+						{`${parsed.errors.length} unreadable line${parsed.errors.length > 1 ? 's' : ''} skipped. Run \`nanotune data validate\` to see which; editing and deleting stay blocked until they are fixed.`}
+					</StatusMessage>
 				</Box>
 			)}
 

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -7,17 +7,14 @@ import {
 	useAutoExit,
 	useKeyInput,
 } from '../../components/index.js';
-import {
-	configExists,
-	loadConfig,
-	resolveContextMessage,
-} from '../../lib/config.js';
+import {resolveContextMessage, tryLoadConfig} from '../../lib/config.js';
 import {
 	type ContextFixResult,
 	countExamples,
 	type DedupeResult,
 	dedupeExamples,
 	fixContextMessages,
+	parseTrainingData,
 	validateTrainingData,
 } from '../../lib/data.js';
 
@@ -33,7 +30,7 @@ export function DataValidateCommand({
 	isEval = false,
 }: Props) {
 	const {exit} = useApp();
-	const hasConfig = configExists();
+	const {config, error: configError} = tryLoadConfig();
 
 	useKeyInput((input, key) => {
 		if (key.escape || input === 'q' || key.return) {
@@ -44,14 +41,19 @@ export function DataValidateCommand({
 	const setName = isEval ? 'Validation data' : 'Training data';
 	const title = isEval ? 'Validate Validation Data' : 'Validate Training Data';
 
+	// Both fixes rewrite the whole file, so neither may run on data we could
+	// not fully parse: they would drop the malformed lines rather than let the
+	// report point at them.
+	const parseErrors = config ? parseTrainingData(isEval).errors : [];
+
 	let dedupeResult: DedupeResult | null = null;
 	let contextFixResult: ContextFixResult | null = null;
-	if (hasConfig) {
+	if (config && parseErrors.length === 0) {
 		// Rewrite context first: examples that only become identical after
 		// context normalization must still be caught by dedupe in this pass.
 		if (rewriteContext) {
 			contextFixResult = fixContextMessages(
-				resolveContextMessage(loadConfig()),
+				resolveContextMessage(config),
 				isEval,
 			);
 		}
@@ -62,22 +64,20 @@ export function DataValidateCommand({
 
 	// Re-validate after fixes are applied so the report reflects the data
 	// actually left on disk.
-	const count = hasConfig ? countExamples(isEval) : 0;
-	const result = hasConfig
-		? validateTrainingData(resolveContextMessage(loadConfig()), isEval)
+	const count = config ? countExamples(isEval) : 0;
+	const result = config
+		? validateTrainingData(resolveContextMessage(config), isEval)
 		: null;
 
 	// Report is fully rendered on first pass — without a keyboard there is
 	// nothing to wait for. Invalid data exits non-zero so CI can gate on it.
-	useAutoExit(true, !hasConfig || !result?.valid);
+	useAutoExit(true, !config || !result?.valid);
 
-	if (!hasConfig || !result) {
+	if (!config || !result) {
 		return (
 			<Box flexDirection="column" padding={1}>
 				<Header title={title} />
-				<StatusMessage variant="error">
-					Not a Nanotune project. Run `nanotune init` first.
-				</StatusMessage>
+				<StatusMessage variant="error">{configError}</StatusMessage>
 			</Box>
 		);
 	}

--- a/src/commands/export.tsx
+++ b/src/commands/export.tsx
@@ -21,6 +21,7 @@ import {
 	hasUsableFusedModel,
 	loadConfig,
 	skipFuseValidationError,
+	tryLoadConfig,
 } from '../lib/config.js';
 import {
 	checkLlamaCppInstalled,
@@ -202,18 +203,18 @@ export function ExportCommand({options}: Props) {
 		run();
 	}, [run]);
 
-	if (!configExists()) {
+	// Never `loadConfig()` here: a throw in the render body escapes the
+	// run callback's own error handling and aborts the render, so the
+	// effect that sets a non-zero exit code never runs.
+	const {config, error: configError} = tryLoadConfig();
+	if (!config) {
 		return (
 			<Box flexDirection="column" padding={1}>
 				<Header title="Export" />
-				<StatusMessage variant="error">
-					Not a Nanotune project. Run `nanotune init` first.
-				</StatusMessage>
+				<StatusMessage variant="error">{configError}</StatusMessage>
 			</Box>
 		);
 	}
-
-	const config = loadConfig();
 	const quantization = options.quantization || config.export.quantization;
 
 	return (

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -21,7 +21,7 @@ import {
 	getModelsDir,
 	hasUsableFusedModel,
 	loadBenchmark,
-	loadConfig,
+	tryLoadConfig,
 } from '../lib/config.js';
 import {countExamples} from '../lib/data.js';
 import type {BenchmarkResult} from '../types/index.js';
@@ -43,6 +43,7 @@ function formatRelativeTime(date: Date): string {
 
 export function StatusCommand() {
 	const {exit} = useApp();
+	const {config, error: configError} = tryLoadConfig();
 	const hasConfig = configExists();
 	const fusedDir = getFusedModelDir();
 	const fusedExists = hasConfig && hasUsableFusedModel(fusedDir);
@@ -58,20 +59,17 @@ export function StatusCommand() {
 	});
 
 	// Nothing to wait for without a keyboard — render the report and leave.
-	useAutoExit(true, !hasConfig);
+	useAutoExit(true, !config);
 
-	if (!hasConfig) {
+	if (!config) {
 		return (
 			<Box flexDirection="column" padding={1}>
 				<Header title="Project Status" />
-				<StatusMessage variant="error">
-					Not a Nanotune project. Run `nanotune init` first.
-				</StatusMessage>
+				<StatusMessage variant="error">{configError}</StatusMessage>
 			</Box>
 		);
 	}
 
-	const config = loadConfig();
 	const dataDir = getDataDir();
 	const adaptersDir = getAdaptersDir();
 	const modelsDir = getModelsDir();

--- a/src/commands/train.tsx
+++ b/src/commands/train.tsx
@@ -16,6 +16,7 @@ import {
 	getAdaptersDir,
 	getDataDir,
 	loadConfig,
+	tryLoadConfig,
 } from '../lib/config.js';
 import {countExamples, ensureValidationSet} from '../lib/data.js';
 import {
@@ -383,18 +384,18 @@ export function TrainCommand({options}: Props) {
 		run();
 	}, [run]);
 
-	if (!configExists()) {
+	// Never `loadConfig()` here: a throw in the render body escapes the
+	// run callback's own error handling and aborts the render, so the
+	// effect that sets a non-zero exit code never runs.
+	const {config, error: configError} = tryLoadConfig();
+	if (!config) {
 		return (
 			<Box flexDirection="column" padding={1}>
 				<Header title="Training" />
-				<StatusMessage variant="error">
-					Not a Nanotune project. Run `nanotune init` first.
-				</StatusMessage>
+				<StatusMessage variant="error">{configError}</StatusMessage>
 			</Box>
 		);
 	}
-
-	const config = loadConfig();
 	// This component re-renders on every training update, so prefer the counts
 	// the split already returned over re-reading both files each time.
 	const exampleCount = split ? split.trainCount : countExamples();

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -24,6 +24,7 @@ import {
   findUnknownConfigKeys,
   loadConfig,
   resolveContextMessage,
+  tryLoadConfig,
   writeFileAtomic,
 } from "./config.js";
 
@@ -798,6 +799,66 @@ test("skipFuseValidationError reports a clear error when --skip-fuse is set but 
   t.true(message!.includes("fused"));
 });
 
+
+// ── malformed config.json ─────────────────────────────────────────────
+
+const BAD_CONFIG_DIR = join(ORIG_CWD, ".test-config-malformed");
+
+function withBadConfig(contents: string, run: () => void) {
+  rmSync(BAD_CONFIG_DIR, { recursive: true, force: true });
+  mkdirSync(join(BAD_CONFIG_DIR, ".nanotune"), { recursive: true });
+  if (contents) {
+    writeFileSync(join(BAD_CONFIG_DIR, ".nanotune", "config.json"), contents);
+  }
+  process.chdir(BAD_CONFIG_DIR);
+  try {
+    run();
+  } finally {
+    process.chdir(ORIG_CWD);
+    rmSync(BAD_CONFIG_DIR, { recursive: true, force: true });
+  }
+}
+
+test.serial("loadConfig names the file when it is not valid JSON", (t) => {
+  withBadConfig('{"name":"v","baseMod', () => {
+    const err = t.throws(() => loadConfig());
+    // The bare parser message ("Unterminated string in JSON at position 20")
+    // names neither the file nor the command that ran into it.
+    t.true(err?.message.startsWith("Invalid config.json: not valid JSON"));
+  });
+});
+
+test.serial("tryLoadConfig reports malformed JSON instead of throwing", (t) => {
+  withBadConfig('{"name":"v","baseMod', () => {
+    const { config, error } = tryLoadConfig();
+    t.is(config, null);
+    t.true(error?.startsWith("Invalid config.json: not valid JSON"));
+  });
+});
+
+test.serial("tryLoadConfig reports a schema-invalid config", (t) => {
+  withBadConfig(JSON.stringify({ name: "v", version: "1.0.0" }), () => {
+    const { config, error } = tryLoadConfig();
+    t.is(config, null);
+    t.true(error?.includes("baseModel"));
+  });
+});
+
+test.serial("tryLoadConfig reports a missing project", (t) => {
+  withBadConfig("", () => {
+    const { config, error } = tryLoadConfig();
+    t.is(config, null);
+    t.is(error, "Not a Nanotune project. Run `nanotune init` first.");
+  });
+});
+
+test.serial("tryLoadConfig returns the config when it is valid", (t) => {
+  withBadConfig(JSON.stringify(KNOWN_KEYS_CONFIG), () => {
+    const { config, error } = tryLoadConfig();
+    t.is(error, null);
+    t.is(config?.name, KNOWN_KEYS_CONFIG.name);
+  });
+});
 
 // ── ensureBenchmarksDir ───────────────────────────────────────────────
 //

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -252,7 +252,16 @@ export function loadConfig(): Config {
 	if (!existsSync(path)) {
 		throw new Error('Not a Nanotune project. Run `nanotune init` first.');
 	}
-	const raw = JSON.parse(readFileSync(path, 'utf-8'));
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(path, 'utf-8'));
+	} catch (err) {
+		// A truncated or hand-edited file reaches the UI as a bare parser
+		// message ("Unterminated string in JSON at position 38") that names
+		// neither the file nor the command. Say which file is unreadable.
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`Invalid ${CONFIG_FILE}: not valid JSON (${detail})`);
+	}
 	for (const warning of findUnknownConfigKeys(raw)) {
 		if (!warnedKeys.has(warning)) {
 			warnedKeys.add(warning);
@@ -264,6 +273,24 @@ export function loadConfig(): Config {
 		throw new Error(formatConfigIssues(result.error));
 	}
 	return result.data;
+}
+
+/**
+ * `loadConfig` for a component's render body, where a throw escapes the
+ * command's own try/catch and lands in Ink's error boundary — which aborts
+ * the render, so the effect that sets a non-zero exit code never runs and the
+ * command dies with a reconciler trace and status 0. Returning the failure
+ * lets the caller render it as an ordinary error state.
+ */
+export function tryLoadConfig(): {config: Config | null; error: string | null} {
+	try {
+		return {config: loadConfig(), error: null};
+	} catch (err) {
+		return {
+			config: null,
+			error: err instanceof Error ? err.message : 'Failed to load config',
+		};
+	}
 }
 
 export function saveConfig(config: Config): void {

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -23,6 +23,7 @@ import {
   loadTrainingData,
   mergeEditedTurn,
   parseCSV,
+  parseTrainingData,
   splitTrainValidation,
   updateTrainingExample,
   validateTrainingData,
@@ -602,6 +603,86 @@ test.serial("importData dispatches .json to importFromJSON", (t) => {
   const result = importData(jsonPath, SYSTEM_CTX, false);
   t.is(result.imported, 1);
   t.is(loadTrainingData(false)[0].messages[1].content, "a");
+});
+
+// ── malformed train.jsonl ─────────────────────────────────────────────
+
+const GOOD_LINE = JSON.stringify({
+  messages: [
+    SYSTEM_CTX,
+    { role: "user", content: "A" },
+    { role: "assistant", content: "B" },
+  ],
+});
+
+function writeRawTrain(contents: string) {
+  writeFileSync(join(DATA_DIR, "train.jsonl"), contents);
+}
+
+test.serial("parseTrainingData reports a bad line instead of throwing", (t) => {
+  writeRawTrain(GOOD_LINE + "\nnot json at all\n" + GOOD_LINE + "\n");
+
+  const { examples, errors } = parseTrainingData(false);
+  t.is(examples.length, 2);
+  t.deepEqual(errors, ["Example 2: invalid JSON"]);
+});
+
+test.serial("parseTrainingData numbers bad lines by file position", (t) => {
+  writeRawTrain("bad\n" + GOOD_LINE + "\nalso bad\n");
+
+  const { examples, errors } = parseTrainingData(false);
+  t.is(examples.length, 1);
+  t.deepEqual(errors, ["Example 1: invalid JSON", "Example 3: invalid JSON"]);
+});
+
+test.serial("parseTrainingData reports nothing on clean data", (t) => {
+  writeRawTrain(GOOD_LINE + "\n");
+
+  const { examples, errors } = parseTrainingData(false);
+  t.is(examples.length, 1);
+  t.deepEqual(errors, []);
+});
+
+test.serial("loadTrainingData still throws, naming the bad line", (t) => {
+  writeRawTrain(GOOD_LINE + "\nnope\n");
+
+  // Deliberately strict: the mutating helpers load, transform and write the
+  // whole file back, so skipping the line here would delete it on save.
+  const err = t.throws(() => loadTrainingData(false));
+  t.is(err?.message, "Example 2: invalid JSON");
+});
+
+test.serial("a malformed line survives a failed delete", (t) => {
+  writeRawTrain(GOOD_LINE + "\nnope\n");
+  const before = readFileSync(join(DATA_DIR, "train.jsonl"), "utf-8");
+
+  t.throws(() => deleteExample(0, false));
+  t.is(readFileSync(join(DATA_DIR, "train.jsonl"), "utf-8"), before);
+});
+
+test.serial("a malformed line survives a failed dedupe", (t) => {
+  writeRawTrain(GOOD_LINE + "\n" + GOOD_LINE + "\nnope\n");
+  const before = readFileSync(join(DATA_DIR, "train.jsonl"), "utf-8");
+
+  t.throws(() => dedupeExamples(false));
+  t.is(readFileSync(join(DATA_DIR, "train.jsonl"), "utf-8"), before);
+});
+
+test.serial("validateTrainingData reports a bad line as an error", (t) => {
+  writeRawTrain(GOOD_LINE + "\nnot json at all\n");
+
+  const result = validateTrainingData(SYSTEM_CTX, false);
+  t.false(result.valid);
+  t.true(result.errors.includes("Example 2: invalid JSON"));
+});
+
+test.serial("validateTrainingData does not call a malformed file empty", (t) => {
+  writeRawTrain("not json at all\n");
+
+  const result = validateTrainingData(SYSTEM_CTX, false);
+  t.false(result.valid);
+  t.deepEqual(result.errors, ["Example 1: invalid JSON"]);
+});
 });
 
 // ── importData ────────────────────────────────────────────────────────

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -683,7 +683,6 @@ test.serial("validateTrainingData does not call a malformed file empty", (t) => 
   t.false(result.valid);
   t.deepEqual(result.errors, ["Example 1: invalid JSON"]);
 });
-});
 
 // ── importData ────────────────────────────────────────────────────────
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -39,19 +39,51 @@ export function countExamples(isEval = false): number {
 	return content.split('\n').filter(line => line.trim()).length;
 }
 
-export function loadTrainingData(isEval = false): TrainingExample[] {
+export interface ParsedTrainingData {
+	examples: TrainingExample[];
+	/** One `Example N: invalid JSON` per unparseable line, in file order. */
+	errors: string[];
+}
+
+/**
+ * Read the dataset without throwing, collecting unparseable lines as errors
+ * instead. `data validate` exists to find malformed training data, so it has
+ * to survive encountering some and report the offending line like any other
+ * check; the same goes for `data list`, which renders whatever it can.
+ */
+export function parseTrainingData(isEval = false): ParsedTrainingData {
+	const examples: TrainingExample[] = [];
+	const errors: string[] = [];
 	const path = isEval ? getEvalDataPath() : getTrainDataPath();
 	if (!existsSync(path)) {
-		return [];
+		return {examples, errors};
 	}
 	const content = readFileSync(path, 'utf-8').trim();
 	if (!content) {
-		return [];
+		return {examples, errors};
 	}
-	return content
-		.split('\n')
-		.filter(line => line.trim())
-		.map(line => JSON.parse(line) as TrainingExample);
+	const lines = content.split('\n').filter(line => line.trim());
+	lines.forEach((line, i) => {
+		try {
+			examples.push(JSON.parse(line) as TrainingExample);
+		} catch {
+			errors.push(`Example ${i + 1}: invalid JSON`);
+		}
+	});
+	return {examples, errors};
+}
+
+/**
+ * Every example, or a throw naming the first bad line. Kept strict because
+ * the mutating helpers load, transform and write the whole file back, so
+ * quietly skipping a line here would delete it on the next save.
+ */
+export function loadTrainingData(isEval = false): TrainingExample[] {
+	const {examples, errors} = parseTrainingData(isEval);
+	if (errors.length > 0) {
+		throw new Error(errors[0]);
+	}
+	return examples;
 }
 
 /**
@@ -182,12 +214,17 @@ export function validateTrainingData(
 	contextMessage: ChatMessage,
 	isEval = false,
 ): ValidationResult {
-	const errors: string[] = [];
 	const warnings: string[] = [];
-	const examples = loadTrainingData(isEval);
+	const {examples, errors} = parseTrainingData(isEval);
 
 	if (examples.length === 0) {
-		errors.push(isEval ? 'No validation data found' : 'No training data found');
+		// "No data" would be a lie when the file is full of lines we could not
+		// parse - the parse errors already say what is wrong.
+		if (errors.length === 0) {
+			errors.push(
+				isEval ? 'No validation data found' : 'No training data found',
+			);
+		}
 		return {valid: false, errors, warnings};
 	}
 


### PR DESCRIPTION
## Description

Fixes #126.

`loadConfig()` and `loadTrainingData()` both called `JSON.parse` unguarded, and
both were called from React render bodies rather than from effects or lazy
state. A throw during render escapes the try/catch each command wraps around its
async work and lands in Ink's error boundary; because the render never
completes, `useAutoExit` never runs, so the `process.exitCode = 1` it would have
set never happens. The commands dumped a reconciler trace and exited 0.

The sharpest edge was `data validate`, whose entire purpose is finding malformed
training data and which could not survive encountering any. It sets a non-zero
code deliberately so CI can gate on invalid data, and that gate passed silently
on the worst input it could receive.

### Four parts

1. **`loadConfig` guards its parse and names the file.** A truncated config
   reports `Invalid config.json: not valid JSON (...)` rather than a bare parser
   message identifying neither the file nor the command. This also improves
   `data import`, `data add`, `chat` and `benchmark`, which already exited 1 but
   printed the raw message.

2. **`parseTrainingData()` returns `{examples, errors}` without throwing**, so
   `validateTrainingData` reports `Example 2: invalid JSON` alongside every other
   check and `data list` renders the rows it could read. Numbering is by file
   position, so it points at the offending line.

3. **`loadTrainingData` stays strict**, throwing with that same message. The
   mutating helpers load, transform and write the whole file back, so quietly
   skipping a bad line there would delete it on the next save. `data validate`
   correspondingly skips `--fix`/`--rewrite-context` when the data does not fully
   parse, and `data list` blocks edit and delete the same way — the malformed
   line survives for the user to fix rather than being tidied away.

4. **The five render-body call sites use `tryLoadConfig()`**, which returns the
   failure instead of throwing, and `cli.tsx` wraps `render()` so anything that
   still escapes rejects `waitUntilExit()` into one line on stderr and exit code
   1. `process.on('uncaughtException')` would not fire here Ink catches render
   throws in its own error boundary.

One scope note on part 4: I verified the backstop by injecting a synthetic
render-body throw into the built output. It sets exit 1 and prints a single line
to stderr, but Ink still paints its own trace to stdout and that cannot be
suppressed from outside the render. Parts 1–3 are what remove the trace from the
reported cases, by making them not throw at all; the backstop only guarantees the
exit code for something unforeseen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [x] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [x] Tested `nanotune train`
- [x] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)