### PR TITLE
fix(judge): guard `judge configure` on a project and back-fill the .nanotune/.gitignore

### DIFF
--- a/docs/commands/judge.md
+++ b/docs/commands/judge.md
@@ -14,6 +14,11 @@ Set up and test an LLM provider for evaluating open-ended responses during bench
 nanotune judge configure
 ```
 
+Run this inside a Nanotune project. The configuration is written into
+`.nanotune/`, so with no project here the command stops up front — before
+asking for a provider or an API key — and tells you to run `nanotune init`
+first.
+
 Interactively set up an LLM judge. You'll be prompted to:
 
 1. **Select a provider** — Supports both cloud and local providers:

--- a/docs/configuration/judge.md
+++ b/docs/configuration/judge.md
@@ -48,6 +48,18 @@ Default values are also supported:
 
 This resolves at runtime from your shell environment, so the actual key is never stored in the config file.
 
+## Keeping the Key Out of Git
+
+`apiKey` may hold a literal secret rather than the `${ENV_VAR}` form, so
+`judge.json` is written with `0600` permissions and `.nanotune/.gitignore`
+carries a `judge.json*` entry — the glob also covers the `judge.json.tmp` an
+interrupted save can leave behind.
+
+Projects created before that entry existed keep the `.gitignore` they were
+initialised with. Saving a judge configuration back-fills any missing entries
+into the existing file, so a project made with an older Nanotune picks the
+protection up on its next `nanotune judge configure`.
+
 ## Supported Providers
 
 ### Cloud Providers

--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -1,4 +1,12 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 import test from "ava";
 import { Text } from "ink";
@@ -10,7 +18,8 @@ import { DataExportCommand } from "./data/export.js";
 import { DataImportCommand } from "./data/import.js";
 import { DataListCommand } from "./data/list.js";
 import { DataValidateCommand } from "./data/validate.js";
-import { JudgeConfigureCommand } from "./judge.js";
+import { PROVIDER_TEMPLATES } from "../lib/judge-templates.js";
+import { JudgeConfigureCommand, JudgeTestCommand } from "./judge.js";
 import { StatusCommand } from "./status.js";
 
 const ORIG_CWD = process.cwd();
@@ -407,6 +416,306 @@ test.serial("DataExportCommand with --eval exports the validation set", async (t
     t.true(written.includes("valid-one"));
     t.false(written.includes("train-one"));
   } finally {
+    teardown();
+  }
+});
+
+// ── judge test: the states it reaches without a live judge ──────────
+
+test.serial("JudgeTestCommand renders its error state with no project", async (t) => {
+  try {
+    setupEmptyDir();
+    const output = await renderCommand(<JudgeTestCommand />, "Not a Nanotune project");
+    t.true(output.includes("Not a Nanotune project"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeTestCommand reports an unconfigured judge inside a project", async (t) => {
+  try {
+    setupProject();
+    const output = await renderCommand(
+      <JudgeTestCommand />,
+      "LLM judge is not configured",
+    );
+    t.true(output.includes("nanotune judge configure"));
+  } finally {
+    teardown();
+  }
+});
+
+// ── driving the interactive judge configure flow ────────────────────
+//
+// @inkjs/ui swallows the first keypress that lands on a freshly mounted
+// TextInput, so these helpers drive the form by watching the rendered frame
+// rather than by counting keystrokes.
+
+const ENTER = "\r";
+const DOWN = "\x1B[B";
+
+type Rendered = ReturnType<typeof render>;
+
+async function withTTY<T>(run: () => Promise<T>): Promise<T> {
+  const original = process.stdin.isTTY;
+  process.stdin.isTTY = true as true;
+  try {
+    return await run();
+  } finally {
+    process.stdin.isTTY = original;
+  }
+}
+
+async function write(instance: Rendered, text: string) {
+  instance.stdin.write(text);
+  await settle();
+}
+
+/** Wait for `text` to show up in any frame rendered so far. */
+async function waitForFrame(instance: Rendered, text: string) {
+  for (let i = 0; i < 50; i++) {
+    if (instance.frames.join("\n").includes(text)) return true;
+    await settle();
+  }
+  return false;
+}
+
+async function selectProvider(instance: Rendered, id: string) {
+  const index = PROVIDER_TEMPLATES.findIndex((template) => template.id === id);
+  for (let i = 0; i < index; i++) await write(instance, DOWN);
+  await write(instance, ENTER);
+}
+
+/** Fill in the field whose prompt is on screen, then submit it. */
+async function answer(instance: Rendered, prompt: string, value = "") {
+  for (let i = 0; i < 30 && !instance.lastFrame()?.includes(prompt); i++) {
+    await settle();
+  }
+  for (let i = 0; i < 5 && value && !instance.lastFrame()?.includes(value); i++) {
+    await write(instance, value);
+  }
+  for (let i = 0; i < 5; i++) {
+    await write(instance, ENTER);
+    if (!instance.lastFrame()?.includes(prompt)) return;
+  }
+}
+
+async function confirmSave(instance: Rendered) {
+  for (let i = 0; i < 5; i++) {
+    await write(instance, "y");
+    if (!instance.lastFrame()?.includes("Save and test connection?")) return;
+  }
+}
+
+test.serial("JudgeConfigureCommand walks a templated provider to the summary", async (t) => {
+  try {
+    setupProject();
+    await withTTY(async () => {
+      const instance = render(<JudgeConfigureCommand />);
+      await settle();
+      // Ollama defaults both the provider name and the base URL; the model
+      // has no default and is required.
+      await selectProvider(instance, "ollama");
+      await answer(instance, "Provider name");
+      await answer(instance, "Base URL");
+
+      // An empty required field must not advance the form.
+      await write(instance, ENTER);
+      await write(instance, ENTER);
+      t.true(instance.lastFrame()?.includes("Model name"));
+
+      await answer(instance, "Model name", "qwen2.5:0.5b");
+
+      const summary = instance.lastFrame() ?? "";
+      instance.unmount();
+      t.true(summary.includes("Configuration Summary"));
+      t.true(summary.includes("qwen2.5:0.5b"));
+      t.true(summary.includes("http://localhost:11434/v1"));
+      // Ollama needs no key, so the summary says so rather than masking.
+      t.true(summary.includes("(none)"));
+      t.true(summary.includes("Save and test connection?"));
+    });
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand masks the API key on the summary", async (t) => {
+  try {
+    setupProject();
+    await withTTY(async () => {
+      const instance = render(<JudgeConfigureCommand />);
+      await settle();
+      await selectProvider(instance, "gemini");
+      await answer(instance, "API Key", "sk-should-not-be-shown");
+      await answer(instance, "Model name");
+      await answer(instance, "Provider name");
+
+      const summary = instance.lastFrame() ?? "";
+      instance.unmount();
+      t.true(summary.includes("Configuration Summary"));
+      t.false(summary.includes("sk-should-not-be-shown"));
+      t.true(summary.includes("API Key: ***"));
+      t.true(summary.includes("SDK Provider: google"));
+    });
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand rejects a malformed base URL", async (t) => {
+  try {
+    setupProject();
+    await withTTY(async () => {
+      // The custom template leaves the base URL empty, so what is typed is
+      // exactly what the validator sees.
+      const instance = render(<JudgeConfigureCommand />);
+      await settle();
+      await selectProvider(instance, "custom");
+      await answer(instance, "Provider name", "stub");
+      await answer(instance, "Base URL", "not-a-url");
+
+      const frame = instance.lastFrame() ?? "";
+      instance.unmount();
+      t.true(frame.includes("Invalid URL format"));
+      t.false(frame.includes("Configuration Summary"));
+    });
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand writes nothing when the answer is n", async (t) => {
+  try {
+    setupProject();
+    await withTTY(async () => {
+      const instance = render(<JudgeConfigureCommand />);
+      await settle();
+      await selectProvider(instance, "ollama");
+      await answer(instance, "Provider name");
+      await answer(instance, "Base URL");
+      await answer(instance, "Model name", "some-model");
+      t.true(instance.lastFrame()?.includes("Configuration Summary"));
+
+      await write(instance, "n");
+      instance.unmount();
+    });
+    t.false(existsSync(join(NANOTUNE_DIR, "judge.json")));
+  } finally {
+    teardown();
+  }
+});
+
+// ── judge configure: connection test vs. save ───────────────────────
+//
+// The save used to sit inside the connection-test try block, so an ENOENT
+// from the write surfaced as "Connection test failed". These two pin each
+// failure to its own message, against a stub judge on localhost.
+
+interface StubJudge {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function startStubJudge(
+  respond: (res: ServerResponse) => void,
+): Promise<StubJudge> {
+  const server = createServer((_req, res) => respond(res));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function chatCompletion(res: ServerResponse) {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(
+    JSON.stringify({
+      id: "stub",
+      object: "chat.completion",
+      created: 0,
+      model: "stub-model",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content:
+              '{"scores":{"helpful":9},"overall":9,"reasoning":"fine","pass":true}',
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+}
+
+async function configureAgainst(baseUrl: string) {
+  const instance = render(<JudgeConfigureCommand />);
+  await settle();
+  await selectProvider(instance, "custom");
+  await answer(instance, "Provider name", "stub");
+  await answer(instance, "Base URL", baseUrl);
+  await answer(instance, "API Key (optional)");
+  await answer(instance, "Model name", "stub-model");
+  return instance;
+}
+
+test.serial("JudgeConfigureCommand reports a failed connection as a connection failure", async (t) => {
+  const judge = await startStubJudge((res) => {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: { message: "nope" } }));
+  });
+  try {
+    setupProject();
+    await withTTY(async () => {
+      const instance = await configureAgainst(judge.url);
+      t.true(instance.lastFrame()?.includes("Configuration Summary"));
+
+      await confirmSave(instance);
+      t.true(await waitForFrame(instance, "Connection test failed"));
+
+      const frame = instance.lastFrame() ?? "";
+      instance.unmount();
+      t.false(frame.includes("Failed to save judge config"));
+    });
+    // A connection that never worked must not leave a config behind.
+    t.false(existsSync(join(NANOTUNE_DIR, "judge.json")));
+  } finally {
+    await judge.close();
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand reports a failed save as a save failure", async (t) => {
+  const judge = await startStubJudge(chatCompletion);
+  try {
+    setupProject();
+    // A non-empty directory where judge.json belongs: the connection test
+    // passes and only the rename fails, which is the case that used to be
+    // reported as a connection failure.
+    mkdirSync(join(NANOTUNE_DIR, "judge.json", "blocker"), { recursive: true });
+
+    await withTTY(async () => {
+      const instance = await configureAgainst(judge.url);
+      t.true(instance.lastFrame()?.includes("Configuration Summary"));
+
+      await confirmSave(instance);
+      t.true(await waitForFrame(instance, "Failed to save judge config"));
+
+      const frame = instance.lastFrame() ?? "";
+      instance.unmount();
+      t.false(frame.includes("Connection test failed"));
+    });
+  } finally {
+    await judge.close();
     teardown();
   }
 });

--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -10,6 +10,7 @@ import { DataExportCommand } from "./data/export.js";
 import { DataImportCommand } from "./data/import.js";
 import { DataListCommand } from "./data/list.js";
 import { DataValidateCommand } from "./data/validate.js";
+import { JudgeConfigureCommand } from "./judge.js";
 import { StatusCommand } from "./status.js";
 
 const ORIG_CWD = process.cwd();
@@ -137,6 +138,29 @@ test.serial("DataListCommand renders its error state with no project", async (t)
     setupEmptyDir();
     const output = await renderCommand(<DataListCommand />, "Not a Nanotune project");
     t.true(output.includes("Not a Nanotune project"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand renders its error state with no project", async (t) => {
+  try {
+    setupEmptyDir();
+    // The guard has to come before the provider prompt: the save lands in
+    // .nanotune/, so without it the key is asked for, tested, and discarded.
+    const output = await renderCommand(<JudgeConfigureCommand />, "Not a Nanotune project");
+    t.true(output.includes("Not a Nanotune project"));
+    t.false(output.includes("Select a provider"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("JudgeConfigureCommand prompts for a provider inside a project", async (t) => {
+  try {
+    setupProject();
+    const output = await renderCommand(<JudgeConfigureCommand />, "Select a provider");
+    t.true(output.includes("Select a provider"));
   } finally {
     teardown();
   }

--- a/src/commands/judge.tsx
+++ b/src/commands/judge.tsx
@@ -28,7 +28,12 @@ type ConfigureStep =
 
 export function JudgeConfigureCommand() {
 	const {exit} = useApp();
-	const [step, setStep] = useState<ConfigureStep>('select-provider');
+	// Guard before the first prompt: saveJudgeConfig writes into .nanotune/, so
+	// with no project the key the user typed is asked for, used, and thrown
+	// away. Every other command reports this the same way.
+	const [step, setStep] = useState<ConfigureStep>(() =>
+		configExists() ? 'select-provider' : 'error',
+	);
 	const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
 		null,
 	);
@@ -37,7 +42,9 @@ export function JudgeConfigureCommand() {
 	const [builtConfig, setBuiltConfig] = useState<JudgeProviderConfig | null>(
 		null,
 	);
-	const [errorMessage, setErrorMessage] = useState('');
+	const [errorMessage, setErrorMessage] = useState(
+		'Not a Nanotune project. Run `nanotune init` first.',
+	);
 
 	useKeyInput((_input, key) => {
 		if (key.escape) {
@@ -118,12 +125,6 @@ export function JudgeConfigureCommand() {
 					builtConfig,
 					5,
 				);
-
-				if (!cancelled) {
-					saveJudgeConfig(builtConfig);
-					setStep('done');
-					setTimeout(() => exit(), 100);
-				}
 			} catch (err) {
 				if (!cancelled) {
 					setErrorMessage(
@@ -131,7 +132,26 @@ export function JudgeConfigureCommand() {
 					);
 					setStep('error');
 				}
+				return;
 			}
+
+			if (cancelled) return;
+
+			// Saved outside the try above: a failed write is a failed write, and
+			// reporting it as a connection failure sends the user off debugging
+			// their network or their key after both already worked.
+			try {
+				saveJudgeConfig(builtConfig);
+			} catch (err) {
+				setErrorMessage(
+					`Failed to save judge config: ${err instanceof Error ? err.message : 'Unknown error'}`,
+				);
+				setStep('error');
+				return;
+			}
+
+			setStep('done');
+			setTimeout(() => exit(), 100);
 		};
 
 		testConnection();

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -18,6 +18,7 @@ import {
   listBenchmarks,
   resolveBenchmarkPath,
   findUnknownConfigKeys,
+  initializeProjectDirs,
   loadConfig,
   resolveContextMessage,
   writeFileAtomic,
@@ -791,6 +792,99 @@ test.serial("writeFileAtomic surfaces a missing parent rather than inventing one
     const missing = join(BENCH_TEST_DIR, "nope", "tests.json");
     t.throws(() => writeFileAtomic(missing, "[]"), { code: "ENOENT" });
     t.false(existsSync(join(BENCH_TEST_DIR, "nope")));
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+// ── initializeProjectDirs .gitignore back-fill ────────────────────────
+//
+// Entries join GITIGNORE_CONTENTS over releases, but a project keeps the
+// .gitignore it was initialised with. judge.json can hold a literal API key,
+// so an un-backfilled file leaves that key where `git add .` will take it.
+
+const GITIGNORE_PATH = join(BENCH_TEST_DIR, ".nanotune", ".gitignore");
+
+function writeExistingGitignore(contents: string) {
+  mkdirSync(join(BENCH_TEST_DIR, ".nanotune"), { recursive: true });
+  writeFileSync(GITIGNORE_PATH, contents);
+}
+
+function gitignoreLines() {
+  return readFileSync(GITIGNORE_PATH, "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+test.serial("initializeProjectDirs writes the full .gitignore for a new project", (t) => {
+  setupBenchTest();
+  try {
+    initializeProjectDirs();
+    t.deepEqual(gitignoreLines(), [
+      "# Nanotune project artifacts",
+      "adapters/",
+      "models/",
+      "benchmarks/",
+      "chats/",
+      "judge.json*",
+    ]);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("initializeProjectDirs back-fills a pre-1.4.0 .gitignore", (t) => {
+  setupBenchTest();
+  try {
+    // What `nanotune init` wrote before judge.json joined the list.
+    writeExistingGitignore("# Nanotune project artifacts\nadapters/\nmodels/\n");
+
+    initializeProjectDirs();
+
+    const lines = gitignoreLines();
+    t.true(lines.includes("judge.json*"));
+    t.true(lines.includes("benchmarks/"));
+    t.true(lines.includes("chats/"));
+    // Entries already there are neither lost nor repeated.
+    t.is(lines.filter((line) => line === "adapters/").length, 1);
+    t.is(lines.filter((line) => line === "# Nanotune project artifacts").length, 1);
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("initializeProjectDirs upgrades a bare judge.json entry to the glob", (t) => {
+  setupBenchTest();
+  try {
+    // 1.4.0-1.6.x ignored judge.json but not the judge.json.tmp an interrupted
+    // save leaves behind, which holds the same key.
+    writeExistingGitignore(
+      "# Nanotune project artifacts\nadapters/\nmodels/\nbenchmarks/\nchats/\njudge.json\n",
+    );
+
+    initializeProjectDirs();
+
+    t.true(gitignoreLines().includes("judge.json*"));
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("initializeProjectDirs keeps hand-written entries and back-fills only once", (t) => {
+  setupBenchTest();
+  try {
+    // No trailing newline: the appended block must not run onto this line.
+    writeExistingGitignore("scratch/");
+
+    initializeProjectDirs();
+    const first = readFileSync(GITIGNORE_PATH, "utf-8");
+    initializeProjectDirs();
+
+    t.is(readFileSync(GITIGNORE_PATH, "utf-8"), first);
+    const lines = gitignoreLines();
+    t.true(lines.includes("scratch/"));
+    t.is(lines.filter((line) => line === "judge.json*").length, 1);
   } finally {
     teardownBenchTest();
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -233,6 +233,39 @@ chats/
 judge.json*
 `;
 
+/**
+ * Write .gitignore inside .nanotune/ to protect API keys and keep multi-GB
+ * adapters/models out of the user's git history, back-filling entries into a
+ * file that already exists rather than leaving it as it was found. Entries get
+ * added to this list over time and a project keeps whatever .gitignore it was
+ * initialised with: one from 1.3.x or earlier has no judge.json line at all,
+ * and one from 1.4.0-1.6.x has a bare `judge.json` that misses the
+ * judge.json.tmp an interrupted save leaves behind. Both of those files can
+ * hold a literal API key that `git add .` would commit.
+ */
+function writeProjectGitignore(): void {
+	const gitignorePath = join(getProjectDir(), '.gitignore');
+	if (!existsSync(gitignorePath)) {
+		writeFileSync(gitignorePath, GITIGNORE_CONTENTS);
+		return;
+	}
+
+	const existing = readFileSync(gitignorePath, 'utf-8');
+	const present = new Set(existing.split('\n').map(line => line.trim()));
+	const missing = GITIGNORE_CONTENTS.split('\n')
+		.map(line => line.trim())
+		.filter(line => line && !present.has(line));
+	if (missing.length === 0) {
+		return;
+	}
+
+	const separator = existing === '' || existing.endsWith('\n') ? '' : '\n';
+	writeFileSync(
+		gitignorePath,
+		`${existing}${separator}${missing.join('\n')}\n`,
+	);
+}
+
 export function initializeProjectDirs(): void {
 	const dirs = [
 		getProjectDir(),
@@ -248,12 +281,7 @@ export function initializeProjectDirs(): void {
 		}
 	}
 
-	// Write .gitignore inside .nanotune/ to protect API keys and keep
-	// multi-GB adapters/models out of the user's git history.
-	const gitignorePath = join(getProjectDir(), '.gitignore');
-	if (!existsSync(gitignorePath)) {
-		writeFileSync(gitignorePath, GITIGNORE_CONTENTS);
-	}
+	writeProjectGitignore();
 }
 
 /**

--- a/src/lib/judge.spec.ts
+++ b/src/lib/judge.spec.ts
@@ -334,3 +334,51 @@ test.serial('saveJudgeConfig - recovers from a stale temp file', t => {
 		rmSync(dir, {recursive: true, force: true});
 	}
 });
+
+test.serial('saveJudgeConfig - creates the project directory when it is missing', t => {
+	const originalCwd = process.cwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		// No .nanotune/ at all: the exclusive create used to fail with ENOENT
+		// after the key had already been typed and the connection tested, and
+		// the key was discarded.
+		t.notThrows(() =>
+			saveJudgeConfig({
+				name: 'Test',
+				baseUrl: 'https://example.invalid/v1',
+				apiKey: 'sk-secret',
+				model: 'test-model',
+			}),
+		);
+		t.is(JSON.parse(readFileSync(getJudgeConfigPath(), 'utf-8')).name, 'Test');
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('saveJudgeConfig - back-fills judge.json* into an existing .gitignore', t => {
+	const originalCwd = process.cwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		mkdirSync(join(dir, '.nanotune'), {recursive: true});
+		// A project initialised before judge.json joined the list. Writing the
+		// key 0600 is no protection while git is free to commit the file.
+		const gitignore = join(dir, '.nanotune', '.gitignore');
+		writeFileSync(gitignore, '# Nanotune project artifacts\nadapters/\nmodels/\n');
+
+		saveJudgeConfig({
+			name: 'Test',
+			baseUrl: 'https://example.invalid/v1',
+			apiKey: 'sk-secret',
+			model: 'test-model',
+		});
+
+		t.true(readFileSync(gitignore, 'utf-8').split('\n').includes('judge.json*'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
+});

--- a/src/lib/judge.ts
+++ b/src/lib/judge.ts
@@ -15,7 +15,7 @@ import type {
 	JudgeProviderConfig,
 	JudgeResult,
 } from '../types/index.js';
-import {getProjectDir} from './config.js';
+import {getProjectDir, initializeProjectDirs} from './config.js';
 import {substituteEnvVars} from './env-substitution.js';
 
 const JUDGE_CONFIG_FILE = 'judge.json';
@@ -74,8 +74,13 @@ export function loadJudgeConfig(): JudgeProviderConfig {
  * present in a file that is not already 0600 — including when replacing a 0644
  * config left by 1.5.0 or earlier — and an interrupted write cannot leave a
  * truncated judge.json for `loadJudgeConfig` to choke on.
+ *
+ * `initializeProjectDirs` runs first for its .gitignore: a 0600 file is no
+ * protection at all if git is free to commit it, and projects initialised
+ * before `judge.json*` joined that list never got the entry.
  */
 export function saveJudgeConfig(config: JudgeProviderConfig): void {
+	initializeProjectDirs();
 	const path = getJudgeConfigPath();
 	const tmp = `${path}.tmp`;
 	// Clear a temp left behind by a process that died between write and


### PR DESCRIPTION
## Description

Fixes #127. `judge configure` never checked that it was inside a project, and the `.gitignore` that shields `judge.json` was never back-filled into projects created before that entry existed.

**Case A, no project.** `saveJudgeConfig` writes `judge.json.tmp` with flag `wx` straight into `getProjectDir()`. With no `.nanotune/` the write throws `ENOENT`, and because the save sat inside the connection-test `try` block it was caught by the connection-failure handler and shown as `Connection test failed: ENOENT...` after the API call had already succeeded. The user goes off debugging their network or their key, and the key they typed is gone.

**Case B, pre-1.4.0 project.** `.nanotune/.gitignore` is written only by `initializeProjectDirs()`, only from `nanotune init`, and only `if (!existsSync(gitignorePath))`. A project keeps whatever `.gitignore` it was initialised with forever, so one made with 1.3.x or earlier has no `judge.json` line at all, leaving a file that may hold a literal API key sitting where `git add .` will take it. That defeats the point of the careful `0600` `O_CREAT|O_EXCL` write.

Same back-fill also closes the loose end noted when #100 was closed: projects made with 1.4.0–1.6.x have a bare `judge.json` line that does not cover the `judge.json.tmp` an interrupted save leaves behind. Verified before/after with `git check-ignore`.

**Changes**

- `src/commands/judge.tsx`, gate on `configExists()` before the first prompt, with the message every other command uses. Move the save out of the connection-test `try` so a write failure reports itself as a write failure.
- `src/lib/config.ts`, new private `writeProjectGitignore()` merges missing entries into an existing `.gitignore` instead of skipping the write. Trim-compared so it is idempotent, trailing-newline aware so an appended block cannot run onto a hand-written last line, and append-only so it never removes or reorders what is already there.
- `src/lib/judge.ts`, `saveJudgeConfig` calls `initializeProjectDirs()` first, so writing the key is what repairs the file.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)