### PR TITLE
fix(judge): stop env expansion from corrupting literal API keys

### DIFF
--- a/docs/configuration/judge.md
+++ b/docs/configuration/judge.md
@@ -48,6 +48,25 @@ Default values are also supported:
 
 This resolves at runtime from your shell environment, so the actual key is never stored in the config file.
 
+A value is substituted only when it is *entirely* one reference. Anything else
+is a literal and is used exactly as written, so a key pasted from a provider
+console survives even when it contains `$`:
+
+| Value | Result |
+|-------|--------|
+| `"${OPENROUTER_API_KEY}"` | the variable's value |
+| `"${OPENROUTER_API_KEY:-sk-default}"` | the variable's value, or `sk-default` if unset |
+| `"sk-ant-api03-AB$CD-EF"` | used as-is |
+| `"https://${REGION}.example.com/v1"` | used as-is — not a whole-value reference |
+
+If a referenced variable is unset and has no default, nanotune stops and names
+it rather than sending a blank credential:
+
+```
+judge.json "apiKey" is set to ${OPENROUTER_API_KEY}, but that environment
+variable is not set. Export it, or give it a default with ${VAR:-value}.
+```
+
 ## Supported Providers
 
 ### Cloud Providers

--- a/src/lib/env-substitution.spec.ts
+++ b/src/lib/env-substitution.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {substituteEnvVars} from './env-substitution.js';
+import {isUnresolvedEnvRef, substituteEnvVars} from './env-substitution.js';
 
 // Suppress console.error noise from missing env var warnings
 const originalConsoleError = console.error;
@@ -19,10 +19,11 @@ test('substituteEnvVars - returns string with existing env var', t => {
 	delete process.env.TEST_VAR;
 });
 
-test('substituteEnvVars - returns string with unbraced env var', t => {
+test('substituteEnvVars - leaves an unbraced $NAME alone', t => {
+	// The `$NAME` form is gone: it matched any `$` before an uppercase letter,
+	// which is a shape real API keys have.
 	process.env.MY_VAR = 'my_value';
-	const result = substituteEnvVars('$MY_VAR');
-	t.is(result, 'my_value');
+	t.is(substituteEnvVars('$MY_VAR'), '$MY_VAR');
 	delete process.env.MY_VAR;
 });
 
@@ -31,27 +32,40 @@ test('substituteEnvVars - uses default value when env var not set', t => {
 	t.is(result, 'default_value');
 });
 
-test('substituteEnvVars - returns empty string when env var not found and no default', t => {
-	const result = substituteEnvVars('${NONEXISTENT_VAR_XYZ}');
-	t.is(result, '');
+test('substituteEnvVars - leaves the reference intact when the var is unset', t => {
+	// Not '': a blank credential reaches the provider as a 401 that blames the
+	// user's account. The intact reference lets loadJudgeConfig name the variable.
+	t.is(substituteEnvVars('${NONEXISTENT_VAR_XYZ}'), '${NONEXISTENT_VAR_XYZ}');
 });
 
-test('substituteEnvVars - substitutes multiple vars in one string', t => {
+test('substituteEnvVars - resolves a variable that is set but empty', t => {
+	// Set-but-empty is still set, so it wins over both the default and the
+	// leave-it-alone fallback.
+	process.env.EMPTY_VAR = '';
+	t.is(substituteEnvVars('${EMPTY_VAR}'), '');
+	delete process.env.EMPTY_VAR;
+});
+
+test('substituteEnvVars - honours an empty default', t => {
+	t.is(substituteEnvVars('${NONEXISTENT_VAR_XYZ:-}'), '');
+});
+
+test('substituteEnvVars - leaves a string holding several references alone', t => {
+	// Only a whole-value reference substitutes, so this is a literal now.
 	process.env.FIRST = 'hello';
 	process.env.SECOND = 'world';
-	const result = substituteEnvVars('${FIRST} ${SECOND}');
-	t.is(result, 'hello world');
+	t.is(substituteEnvVars('${FIRST} ${SECOND}'), '${FIRST} ${SECOND}');
 	delete process.env.FIRST;
 	delete process.env.SECOND;
 });
 
-test('substituteEnvVars - handles mixed braced and unbraced vars', t => {
-	process.env.VAR1 = 'a';
-	process.env.VAR2 = 'b';
-	const result = substituteEnvVars('${VAR1} and $VAR2');
-	t.is(result, 'a and b');
-	delete process.env.VAR1;
-	delete process.env.VAR2;
+test('substituteEnvVars - leaves an embedded reference alone', t => {
+	process.env.HOST_VAR = 'example.com';
+	t.is(
+		substituteEnvVars('https://${HOST_VAR}/v1'),
+		'https://${HOST_VAR}/v1',
+	);
+	delete process.env.HOST_VAR;
 });
 
 // Non-string input
@@ -80,8 +94,8 @@ test('substituteEnvVars - returns undefined unchanged', t => {
 
 test('substituteEnvVars - substitutes vars in array of strings', t => {
 	process.env.ARRAY_VAR = 'array_value';
-	const result = substituteEnvVars(['prefix-${ARRAY_VAR}-suffix']);
-	t.deepEqual(result, ['prefix-array_value-suffix']);
+	const result = substituteEnvVars(['${ARRAY_VAR}', 'prefix-${ARRAY_VAR}']);
+	t.deepEqual(result, ['array_value', 'prefix-${ARRAY_VAR}']);
 	delete process.env.ARRAY_VAR;
 });
 
@@ -133,8 +147,77 @@ test('substituteEnvVars - complex config object', t => {
 	t.deepEqual(result, {
 		server: {host: 'localhost', port: '8080', ssl: true},
 		fallback: 'fallback_url',
-		endpoints: ['localhost/api', 'localhost/health'],
+		// Embedded, so literal.
+		endpoints: ['${HOST}/api', '${HOST}/health'],
 	});
 	delete process.env.HOST;
 	delete process.env.PORT;
+});
+
+// Literal API keys
+
+// Every shape below reached expandEnvVar's old unbraced `$NAME` branch and came
+// back truncated, on every load, while judge.json still read correctly on disk.
+for (const key of [
+	'sk-live$SECRET_PART-abc123',
+	'sk-ant-api03-AB$CD-EF',
+	'sk-live$secret-abc123',
+	'sk-$A$B$C',
+	'$LEADING-dollar',
+	'trailing-dollar$',
+]) {
+	test(`substituteEnvVars - literal key round-trips: ${key}`, t => {
+		// Set, so a surviving expansion swaps in a value rather than '' and the
+		// assertion cannot pass by the variable happening to be unset.
+		process.env.SECRET_PART = 'LEAKED';
+		process.env.CD = 'LEAKED';
+		process.env.A = 'LEAKED';
+		process.env.LEADING = 'LEAKED';
+		t.is(substituteEnvVars(key), key);
+		t.false(substituteEnvVars(key).includes('LEAKED'));
+		for (const name of ['SECRET_PART', 'CD', 'A', 'LEADING']) {
+			delete process.env[name];
+		}
+	});
+}
+
+test('substituteEnvVars - a literal key survives inside a judge config', t => {
+	// The path that actually broke: loadJudgeConfig hands the whole parsed
+	// judge.json through, so the key is corrupted in transit rather than on disk.
+	process.env.CD = 'LEAKED';
+	t.deepEqual(
+		substituteEnvVars({
+			name: 'Anthropic',
+			baseUrl: 'https://api.anthropic.com/v1',
+			apiKey: 'sk-ant-api03-AB$CD-EF',
+			model: 'claude-haiku',
+		}),
+		{
+			name: 'Anthropic',
+			baseUrl: 'https://api.anthropic.com/v1',
+			apiKey: 'sk-ant-api03-AB$CD-EF',
+			model: 'claude-haiku',
+		},
+	);
+	delete process.env.CD;
+});
+
+// isUnresolvedEnvRef
+
+test('isUnresolvedEnvRef - true for a bare reference', t => {
+	t.true(isUnresolvedEnvRef('${SOME_VAR}'));
+});
+
+test('isUnresolvedEnvRef - false for a literal key that contains a dollar', t => {
+	// The guard must never reject a key the user pasted verbatim.
+	t.false(isUnresolvedEnvRef('sk-ant-api03-AB$CD-EF'));
+	t.false(isUnresolvedEnvRef('https://${HOST}/v1'));
+	t.false(isUnresolvedEnvRef(''));
+	t.false(isUnresolvedEnvRef(undefined));
+});
+
+test('isUnresolvedEnvRef - false once the reference has resolved', t => {
+	process.env.RESOLVED_VAR = 'a-real-value';
+	t.false(isUnresolvedEnvRef(substituteEnvVars('${RESOLVED_VAR}')));
+	delete process.env.RESOLVED_VAR;
 });

--- a/src/lib/env-substitution.ts
+++ b/src/lib/env-substitution.ts
@@ -1,39 +1,48 @@
-// Expand environment variable references in a string.
-// Stays silent on missing vars; callers downstream will surface a clear error
-// when an empty value (e.g. blank API key) fails the actual operation. We
-// can't write to stdout/stderr from a TUI-rendered process without scrambling
-// Ink's output.
+/**
+ * A value that is *entirely* one `${VAR}` or `${VAR:-default}` reference.
+ *
+ * Anchored on purpose. The previous pattern also expanded a bare `$NAME`
+ * anywhere inside a string, so a key pasted verbatim from a provider console —
+ * `sk-ant-api03-AB$CD-EF` — was silently truncated to `sk-ant-api03-AB-EF` at
+ * load time. judge.json still read correctly on disk, so inspecting the file
+ * proved nothing; the corruption happened on every load. These values are
+ * credentials, so the rule is now exact: a value either *is* a reference, or it
+ * is a literal that round-trips byte for byte.
+ */
+const ENV_REFERENCE = /^\$\{([A-Z_][A-Z0-9_]*)(?::-(.*))?\}$/s;
+
+/**
+ * Expand a `${VAR}` reference, or return the string untouched.
+ *
+ * An unset variable with no default leaves the reference in place rather than
+ * collapsing to ''. A blank credential is indistinguishable from a wrong one by
+ * the time it reaches the provider, and the 401 that comes back sends people to
+ * debug their provider account; the intact `${VAR}` lets `loadJudgeConfig` name
+ * the variable that is actually missing.
+ */
 function expandEnvVar(str: string): string {
 	if (typeof str !== 'string') {
 		return str;
 	}
 
-	const regex = /\$\{([A-Z_][A-Z0-9_]*)(?::-(.*?))?\}|\$([A-Z_][A-Z0-9_]*)/g;
+	const match = ENV_REFERENCE.exec(str);
+	if (!match) {
+		return str;
+	}
 
-	return str.replace(
-		regex,
-		(
-			_match: string,
-			bracedVarName: string | undefined,
-			defaultValue: string | undefined,
-			unbracedVarName: string | undefined,
-		) => {
-			const varName = bracedVarName || unbracedVarName;
-			if (!varName) return '';
+	const [, varName, defaultValue] = match;
 
-			const envValue = process.env[varName];
+	// `??` and not `||`: a variable that is set but empty is still set, and an
+	// empty `${VAR:-}` default is a deliberate empty value.
+	return process.env[varName] ?? defaultValue ?? str;
+}
 
-			if (envValue !== undefined) {
-				return envValue;
-			}
-
-			if (defaultValue !== undefined) {
-				return defaultValue;
-			}
-
-			return '';
-		},
-	);
+/**
+ * Whether `value` is a reference `substituteEnvVars` could not resolve, i.e.
+ * the variable is unset and no default was given.
+ */
+export function isUnresolvedEnvRef(value: unknown): value is string {
+	return typeof value === 'string' && ENV_REFERENCE.test(value);
 }
 
 // Recursively substitute environment variables in objects, arrays, and strings

--- a/src/lib/judge.spec.ts
+++ b/src/lib/judge.spec.ts
@@ -14,6 +14,7 @@ import {
 	buildJudgePrompt,
 	getJudgeConfigPath,
 	JUDGE_CRITERIA,
+	loadJudgeConfig,
 	parseJudgeResponse,
 	resolveCriteria,
 	saveJudgeConfig,
@@ -333,4 +334,91 @@ test.serial('saveJudgeConfig - recovers from a stale temp file', t => {
 		process.chdir(originalCwd);
 		rmSync(dir, {recursive: true, force: true});
 	}
+});
+
+// loadJudgeConfig
+
+/** Run `body` in a throwaway project directory holding this judge.json. */
+function withJudgeConfig(config: unknown, body: () => void): void {
+	const originalCwd = process.cwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nanotune-judge-'));
+	try {
+		process.chdir(dir);
+		mkdirSync(join(dir, '.nanotune'), {recursive: true});
+		writeFileSync(join(dir, '.nanotune', 'judge.json'), JSON.stringify(config));
+		body();
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
+}
+
+test.serial('loadJudgeConfig - a literal key containing $ survives the load', t => {
+	// The whole bug, end to end: judge.json on disk was always right, and the key
+	// was truncated between reading it and handing it to the provider.
+	process.env.CD = 'LEAKED';
+	withJudgeConfig(
+		{
+			name: 'Anthropic',
+			baseUrl: 'https://api.anthropic.com/v1',
+			apiKey: 'sk-ant-api03-AB$CD-EF',
+			model: 'claude-haiku',
+		},
+		() => {
+			t.is(loadJudgeConfig().apiKey, 'sk-ant-api03-AB$CD-EF');
+		},
+	);
+	delete process.env.CD;
+});
+
+test.serial('loadJudgeConfig - resolves the documented ${VAR} form', t => {
+	process.env.NANOTUNE_TEST_KEY = 'sk-from-the-environment';
+	withJudgeConfig(
+		{
+			name: 'OpenRouter',
+			baseUrl: 'https://openrouter.ai/api/v1',
+			apiKey: '${NANOTUNE_TEST_KEY}',
+			model: 'anthropic/claude-haiku',
+		},
+		() => {
+			t.is(loadJudgeConfig().apiKey, 'sk-from-the-environment');
+		},
+	);
+	delete process.env.NANOTUNE_TEST_KEY;
+});
+
+test.serial('loadJudgeConfig - names the variable when it is unset', t => {
+	// Rather than a blank bearer token and a provider 401 that reads as a bad
+	// account, which is what sent people to debug the wrong system.
+	delete process.env.NANOTUNE_UNSET_KEY;
+	withJudgeConfig(
+		{
+			name: 'OpenRouter',
+			baseUrl: 'https://openrouter.ai/api/v1',
+			apiKey: '${NANOTUNE_UNSET_KEY}',
+			model: 'anthropic/claude-haiku',
+		},
+		() => {
+			const error = t.throws(() => loadJudgeConfig(), {
+				instanceOf: Error,
+			});
+			t.true(error?.message.includes('NANOTUNE_UNSET_KEY'));
+			t.true(error?.message.includes('apiKey'));
+		},
+	);
+});
+
+test.serial('loadJudgeConfig - a default keeps an unset variable from throwing', t => {
+	delete process.env.NANOTUNE_UNSET_KEY;
+	withJudgeConfig(
+		{
+			name: 'Ollama',
+			baseUrl: 'http://localhost:11434/v1',
+			apiKey: '${NANOTUNE_UNSET_KEY:-}',
+			model: 'llama3',
+		},
+		() => {
+			t.is(loadJudgeConfig().apiKey, '');
+		},
+	);
 });

--- a/src/lib/judge.ts
+++ b/src/lib/judge.ts
@@ -16,7 +16,7 @@ import type {
 	JudgeResult,
 } from '../types/index.js';
 import {getProjectDir} from './config.js';
-import {substituteEnvVars} from './env-substitution.js';
+import {isUnresolvedEnvRef, substituteEnvVars} from './env-substitution.js';
 
 const JUDGE_CONFIG_FILE = 'judge.json';
 
@@ -62,7 +62,22 @@ export function loadJudgeConfig(): JudgeProviderConfig {
 		);
 	}
 	const raw = JSON.parse(readFileSync(path, 'utf-8')) as JudgeProviderConfig;
-	return substituteEnvVars(raw);
+	const config = substituteEnvVars(raw);
+
+	// An unset `${VAR}` is left in place rather than blanked, so say which one is
+	// missing. Letting it through means a placeholder or empty credential reaches
+	// the provider, and the 401 that comes back reads as a bad account rather than
+	// an unexported shell variable.
+	for (const [field, value] of Object.entries(config)) {
+		if (isUnresolvedEnvRef(value)) {
+			throw new Error(
+				`judge.json "${field}" is set to ${value}, but that environment variable ` +
+					'is not set. Export it, or give it a default with ${VAR:-value}.',
+			);
+		}
+	}
+
+	return config;
 }
 
 /**
@@ -128,7 +143,10 @@ function createJudgeProvider(config: JudgeProviderConfig) {
 	return createOpenAICompatible({
 		name: config.name,
 		baseURL: config.baseUrl,
-		apiKey: config.apiKey ?? 'dummy-key',
+		// `||` and not `??`: an apiKey of '' means no key was configured, which is
+		// what local servers want. `??` let the empty string through and sent an
+		// empty bearer token instead of the placeholder these providers expect.
+		apiKey: config.apiKey || 'dummy-key',
 	});
 }
 


### PR DESCRIPTION
## Description

`expandEnvVar` ran a global regex over every string in `judge.json`, and one of
its two branches matched a bare `$NAME` anywhere in the value. An API key pasted
verbatim from a provider console the input path `judge configure` asks for 
was silently rewritten at load time. The file on disk stayed correct, so
inspecting it proved nothing; the corruption happened on every load.

Substitution now fires only when a value is *entirely* one `${VAR}` or
`${VAR:-default}` reference — the form the docs promise and the unbraced
branch is gone. These values are credentials, so the rule is exact: a value
either **is** a reference, or it is a literal that round-trips byte for byte.

An unset reference is left intact rather than collapsing to `''`, and
`loadJudgeConfig` raises an error naming the variable. Leaving the placeholder
alone is not by itself enough to make the failure name the variable without
the check the literal `${VAR}` just reaches the provider and returns the same
anonymous 401. `apiKey: config.apiKey ?? 'dummy-key'` becomes `||` at the one
call site where `''` genuinely means "no key configured", which is what the
local-server placeholder was always for.

Closes #128

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)