### PR TITLE
fix(data): run validate's dataset fixes once per invocation

### DIFF
--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -243,6 +243,79 @@ test.serial("DataValidateCommand reports errors and warnings", async (t) => {
   }
 });
 
+// ── data validate writes once per invocation ─────────────────
+
+// The fixes used to sit loose in the render body, where nothing bounded how
+// often they ran. No event reaches this component today — a terminal resize
+// drives Ink's output pass, not React's reconciler — so this guards the next
+// state or context someone adds here, and these are the tests that would catch
+// it. Forcing a second render pass asserts the invariant directly: put the bad
+// data back in between, and a write that re-runs cleans it up again where a
+// write that ran once leaves it.
+
+test.serial("DataValidateCommand dedupes once, not on every render", async (t) => {
+  const originalTTY = process.stdin.isTTY;
+  try {
+    // A real terminal, so useAutoExit parks on "Press any key to exit" and the
+    // component stays mounted across the second pass, exactly as the bug needs.
+    process.stdin.isTTY = true;
+    setupProject();
+    const duplicated = [example("hello"), example("hello"), example("goodbye")];
+    writeExamples(duplicated);
+
+    const instance = render(<DataValidateCommand fix />);
+    await settle();
+    t.is(loadTrainingData().length, 2, "first pass should dedupe");
+
+    // Re-introduce the duplicate behind the mounted component's back.
+    writeExamples(duplicated);
+    instance.rerender(<DataValidateCommand fix />);
+    await settle();
+
+    t.is(loadTrainingData().length, 3, "second render pass must not dedupe again");
+    instance.unmount();
+  } finally {
+    process.stdin.isTTY = originalTTY;
+    teardown();
+  }
+});
+
+test.serial("DataValidateCommand rewrites context once, not on every render", async (t) => {
+  const originalTTY = process.stdin.isTTY;
+  try {
+    process.stdin.isTTY = true;
+    setupProject();
+    const stale = [
+      {
+        messages: [
+          { role: "system", content: "Stale context." },
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "reply to hello" },
+        ],
+      },
+    ];
+    writeExamples(stale);
+
+    const instance = render(<DataValidateCommand rewriteContext />);
+    await settle();
+    t.is(loadTrainingData()[0].messages[0].content, "You are helpful.");
+
+    writeExamples(stale);
+    instance.rerender(<DataValidateCommand rewriteContext />);
+    await settle();
+
+    t.is(
+      loadTrainingData()[0].messages[0].content,
+      "Stale context.",
+      "second render pass must not rewrite again",
+    );
+    instance.unmount();
+  } finally {
+    process.stdin.isTTY = originalTTY;
+    teardown();
+  }
+});
+
 // ── data import --yes ───────────────────────────────────────────────
 
 test.serial("DataImportCommand with yes skips the confirmation step", async (t) => {

--- a/src/commands/data/validate.tsx
+++ b/src/commands/data/validate.tsx
@@ -1,5 +1,6 @@
 import {StatusMessage} from '@inkjs/ui';
 import {Box, Text, useApp} from 'ink';
+import {useRef} from 'react';
 import {
 	ExitHint,
 	Header,
@@ -18,8 +19,16 @@ import {
 	type DedupeResult,
 	dedupeExamples,
 	fixContextMessages,
+	type ValidationResult,
 	validateTrainingData,
 } from '../../lib/data.js';
+
+interface Report {
+	dedupeResult: DedupeResult | null;
+	contextFixResult: ContextFixResult | null;
+	count: number;
+	result: ValidationResult | null;
+}
 
 interface Props {
 	fix?: boolean;
@@ -44,28 +53,48 @@ export function DataValidateCommand({
 	const setName = isEval ? 'Validation data' : 'Training data';
 	const title = isEval ? 'Validate Validation Data' : 'Validate Training Data';
 
-	let dedupeResult: DedupeResult | null = null;
-	let contextFixResult: ContextFixResult | null = null;
-	if (hasConfig) {
-		// Rewrite context first: examples that only become identical after
-		// context normalization must still be caught by dedupe in this pass.
-		if (rewriteContext) {
-			contextFixResult = fixContextMessages(
-				resolveContextMessage(loadConfig()),
-				isEval,
-			);
+	// Everything that touches the dataset happens once per invocation, here.
+	// `--fix` and `--rewrite-context` rewrite train.jsonl, and a render body
+	// carries no promise about how many times it runs. Nothing re-renders this
+	// component today — it holds no state and sits at the root of the tree — but
+	// that is a fact about the current tree, not a guarantee. Any state, context
+	// or parent re-render added later would replay the write silently, with no
+	// user action behind it.
+	//
+	// A ref rather than an effect: the fixes have to land before the first frame
+	// reports on them, and before useAutoExit below reads result.valid to decide
+	// the exit code. An effect would run after both.
+	const reportRef = useRef<Report | null>(null);
+	if (reportRef.current === null) {
+		let dedupeResult: DedupeResult | null = null;
+		let contextFixResult: ContextFixResult | null = null;
+		if (hasConfig) {
+			// Rewrite context first: examples that only become identical after
+			// context normalization must still be caught by dedupe in this pass.
+			if (rewriteContext) {
+				contextFixResult = fixContextMessages(
+					resolveContextMessage(loadConfig()),
+					isEval,
+				);
+			}
+			if (fix) {
+				dedupeResult = dedupeExamples(isEval);
+			}
 		}
-		if (fix) {
-			dedupeResult = dedupeExamples(isEval);
-		}
+
+		reportRef.current = {
+			dedupeResult,
+			contextFixResult,
+			// Re-validate after fixes are applied so the report reflects the data
+			// actually left on disk.
+			count: hasConfig ? countExamples(isEval) : 0,
+			result: hasConfig
+				? validateTrainingData(resolveContextMessage(loadConfig()), isEval)
+				: null,
+		};
 	}
 
-	// Re-validate after fixes are applied so the report reflects the data
-	// actually left on disk.
-	const count = hasConfig ? countExamples(isEval) : 0;
-	const result = hasConfig
-		? validateTrainingData(resolveContextMessage(loadConfig()), isEval)
-		: null;
+	const {dedupeResult, contextFixResult, count, result} = reportRef.current;
 
 	// Report is fully rendered on first pass — without a keyboard there is
 	// nothing to wait for. Invalid data exits non-zero so CI can gate on it.

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "ava";
 import type { TrainingExample } from "../types/index.js";
@@ -23,6 +23,7 @@ import {
   loadTrainingData,
   mergeEditedTurn,
   parseCSV,
+  saveTrainingData,
   splitTrainValidation,
   updateTrainingExample,
   validateTrainingData,
@@ -126,6 +127,30 @@ test.serial("an example with no context message still validates", (t) => {
   const result = validateTrainingData(SYSTEM_CTX);
   t.deepEqual(result.errors, []);
   t.true(result.valid);
+});
+
+// ── saveTrainingData ─────────────────────────────────────
+
+test.serial("saveTrainingData replaces the file without leaving a temp behind", (t) => {
+  // The dataset write goes through writeFileAtomic now, so for the first time
+  // it can leave a temp file next to train.jsonl. writeFileAtomic's own
+  // guarantees are covered in config.spec.ts; what this pins is that the data
+  // directory the user looks at is left holding the dataset and nothing else.
+  saveTrainingData([
+    { messages: [SYSTEM_CTX, { role: "user", content: "a" }, { role: "assistant", content: "A" }] },
+  ]);
+  saveTrainingData([
+    { messages: [SYSTEM_CTX, { role: "user", content: "b" }, { role: "assistant", content: "B" }] },
+    { messages: [SYSTEM_CTX, { role: "user", content: "c" }, { role: "assistant", content: "C" }] },
+  ]);
+
+  const data = loadTrainingData();
+  t.is(data.length, 2);
+  t.is(data[0].messages[1].content, "b");
+  t.deepEqual(
+    readdirSync(DATA_DIR).filter((f) => f.includes(".tmp")),
+    [],
+  );
 });
 
 // ── deleteExample ─────────────────────────────────────────────────────

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import {join} from 'node:path';
 import type {ChatMessage, TrainingExample} from '../types/index.js';
-import {getDataDir} from './config.js';
+import {getDataDir, writeFileAtomic} from './config.js';
 
 function ensureDataDir(): void {
 	const dataDir = getDataDir();
@@ -94,7 +94,10 @@ export function saveTrainingData(
 	ensureDataDir();
 	const path = isEval ? getEvalDataPath() : getTrainDataPath();
 	const content = `${examples.map(ex => JSON.stringify(ex)).join('\n')}\n`;
-	writeFileSync(path, content);
+	// Temp-file-and-rename: this rewrites the user's whole dataset, so a crash,
+	// a full disk or a kill between truncate and write would otherwise leave
+	// train.jsonl short of the examples it started with.
+	writeFileAtomic(path, content);
 }
 
 export function deleteExample(index: number, isEval = false): void {


### PR DESCRIPTION
## Description

`--fix` and `--rewrite-context` called `dedupeExamples` and `fixContextMessages`
straight from `DataValidateCommand`'s render body there is no `useEffect`,
`useState` or `useMemo` anywhere in the file. A render body carries no promise
about how many times it runs, and these two rewrite the user's entire dataset.

This PR computes the whole report both fixes, the count and the validation —
once behind a ref and renders from that. A ref rather than an effect because the
fixes have to land before the first frame reports on them, and before
`useAutoExit` reads `result.valid` to pick the exit code; an effect runs after
both. The ordering inside is unchanged, so output and exit code are identical.

Separately, `saveTrainingData` now writes through the `writeFileAtomic` already
used for configs and benchmark reports temp file, then rename instead of a
bare `writeFileSync` that truncates in place.

Refs #133

### Correction to the issue's root cause

The reproduction in #133 does not reproduce, and the PR should not claim it
does. `resized()` in `ink.js` does call `onRender()` unconditionally, but
`onRender()` is Ink's DOM-to-string output pass over the already-reconciled
tree, not a React reconciliation it never re-executes a function component's
body.

Rendering the unfixed component against a TTY-shaped stdout, restoring the
duplicate and firing a real resize:

```
resize listeners      : 1
output frames         : 1 -> 3   (Ink processed the resize)
after terminal resize : 3 examples   => write did NOT re-run
```

Keypresses (`a`, arrow-up, tab) do not re-render it either. The component holds
no state and sits at the root, so today the body runs exactly once per process.

The defect is therefore latent, not live: that is a fact about the current tree,
not a guarantee. Any state, context or parent re-render added here later replays
a full dataset write with no user action behind it, and nothing would catch it.
The fix makes the invariant explicit and test-guarded. The atomic write is
independent of all of this and is reachable today on any platform.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)