### PR TITLE
fix: sweep orphaned atomic-write .temp files after a crashed run

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3,6 +3,7 @@ import {readFileSync} from 'node:fs';
 import {Command} from 'commander';
 import {render} from 'ink';
 import type {ReactElement} from 'react';
+import {getBenchmarksDir, sweepStaleAtomicWrites} from './lib/config.js';
 import {interactiveRequiredMessage, supportsRawMode} from './lib/tty.js';
 
 const pkg = JSON.parse(
@@ -292,5 +293,10 @@ program
 		const {StatusCommand} = await import('./commands/status.js');
 		render(<StatusCommand />);
 	});
+
+// Reap `.tmp-<pid>` leftovers from a previous run that was killed mid-write
+// before its own cleanup could run. Cheap (no-op when the directory doesn't
+// exist) and keeps a crashed `benchmark` from accumulating garbage forever.
+sweepStaleAtomicWrites(getBenchmarksDir());
 
 program.parse();

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -20,6 +20,7 @@ import {
   findUnknownConfigKeys,
   loadConfig,
   resolveContextMessage,
+  sweepStaleAtomicWrites,
   writeFileAtomic,
 } from "./config.js";
 
@@ -791,6 +792,81 @@ test.serial("writeFileAtomic surfaces a missing parent rather than inventing one
     const missing = join(BENCH_TEST_DIR, "nope", "tests.json");
     t.throws(() => writeFileAtomic(missing, "[]"), { code: "ENOENT" });
     t.false(existsSync(join(BENCH_TEST_DIR, "nope")));
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+// ── sweepStaleAtomicWrites ────────────────────────────────────────────
+
+// Above the macOS/Linux pid ceiling, so it can never name a live process.
+const DEAD_PID = 999_999;
+
+test.serial("sweepStaleAtomicWrites is a no-op when the benchmarks directory doesn't exist", (t) => {
+  setupBenchTest();
+  try {
+    t.notThrows(() => sweepStaleAtomicWrites(BENCH_DIR));
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("sweepStaleAtomicWrites removes stale .tmp-<pid> leftovers from a killed run", (t) => {
+  setupBenchTest();
+  try {
+    mkdirSync(BENCH_DIR, { recursive: true });
+    const stale = join(
+      BENCH_DIR,
+      `benchmark-2026-01-01T00-00-00-000Z.json.tmp-${DEAD_PID}`,
+    );
+    const live = join(
+      BENCH_DIR,
+      `benchmark-2026-01-01T00-00-00-000Z.json.tmp-${process.pid}`,
+    );
+    const kept = join(BENCH_DIR, "benchmark-2026-01-01T00-00-00-000Z.json");
+    writeFileSync(stale, "stub");
+    writeFileSync(live, "stub");
+    writeFileSync(kept, "stub");
+
+    sweepStaleAtomicWrites(BENCH_DIR);
+
+    t.false(existsSync(stale));
+    t.true(existsSync(live));
+    t.true(existsSync(kept));
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("writeFileAtomic clears a temp left by a previously killed write to the same file", (t) => {
+  setupBenchTest();
+  try {
+    const dir = ensureBenchmarksDir();
+    const stale = join(dir, `tests.json.tmp-${DEAD_PID}`);
+    writeFileSync(stale, "stale partial write");
+
+    writeFileAtomic(join(dir, "tests.json"), "[1,2]");
+
+    t.false(existsSync(stale));
+    t.is(readFileSync(join(dir, "tests.json"), "utf-8"), "[1,2]");
+  } finally {
+    teardownBenchTest();
+  }
+});
+
+test.serial("writeFileAtomic sweeps only its own target's dead-pid temps", (t) => {
+  setupBenchTest();
+  try {
+    const dir = ensureBenchmarksDir();
+    const unrelated = join(dir, `notes.txt.tmp-${DEAD_PID}`);
+    const noPid = join(dir, "tests.json.tmp");
+    writeFileSync(unrelated, "stub");
+    writeFileSync(noPid, "stub");
+
+    writeFileAtomic(join(dir, "tests.json"), "[1]");
+
+    t.true(existsSync(unrelated));
+    t.true(existsSync(noPid));
   } finally {
     teardownBenchTest();
   }

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -799,8 +799,8 @@ test.serial("writeFileAtomic surfaces a missing parent rather than inventing one
 
 // ── sweepStaleAtomicWrites ────────────────────────────────────────────
 
-// Above the macOS/Linux pid ceiling, so it can never name a live process.
-const DEAD_PID = 999_999;
+// Intentionally above common pid_max values (e.g. Linux default 4,194,304), so it is extremely unlikely to name a live process.
+const DEAD_PID = 9_999_999;
 
 test.serial("sweepStaleAtomicWrites is a no-op when the benchmarks directory doesn't exist", (t) => {
   setupBenchTest();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,8 +8,9 @@ import {
 	statSync,
 	writeFileSync,
 } from 'node:fs';
-import {join} from 'node:path';
+import {basename, dirname, join} from 'node:path';
 import {z} from 'zod';
+import {isProcessAlive} from './model-cache.js';
 import {
 	type BenchmarkResult,
 	type ChatMessage,
@@ -208,14 +209,52 @@ export function saveConfig(config: Config): void {
 }
 
 /**
+ * Remove `.tmp-<pid>` files in `dir` whose owning process is gone. These are
+ * the atomic-write intermediates that accumulate when a process is killed
+ * between its temp write and rename — the `finally` that would normally reap
+ * them never runs. Only files whose pid is dead are swept: a live pid's temp
+ * belongs to a concurrent write (same directory, different target path).
+ * `prefix` restricts the sweep to a single target basename, so a write never
+ * touches unrelated files in a directory it shares with user data.
+ */
+function removeStaleTemps(dir: string, prefix?: string): void {
+	if (!existsSync(dir)) {
+		return;
+	}
+	for (const name of readdirSync(dir)) {
+		if (prefix && !name.startsWith(prefix)) {
+			continue;
+		}
+		const owner = name.match(/\.tmp-(\d+)$/);
+		if (!owner || isProcessAlive(Number.parseInt(owner[1], 10))) {
+			continue;
+		}
+		rmSync(join(dir, name), {force: true});
+	}
+}
+
+/**
+ * Sweep every stale `.tmp-<pid>` sibling in `dir`, regardless of which target
+ * path it belongs to. Run at startup so orphans from a crashed run are gone
+ * the next time any command starts — even when the writing command itself is
+ * never run again. A no-op if `dir` does not exist.
+ */
+export function sweepStaleAtomicWrites(dir: string): void {
+	removeStaleTemps(dir);
+}
+
+/**
  * Write `contents` to `path` via a sibling temp file renamed into place.
  * rename(2) is atomic, so an interrupted or failed write leaves either the
  * previous file or the complete new one — never a truncated file that a later
  * read mistakes for a whole one. The temp carries the pid so concurrent runs
  * cannot scribble over each other's, and the `finally` clears it on the paths
- * where the rename never happened.
+ * where the rename never happened. A process killed mid-write (SIGKILL,
+ * crash) skips that cleanup; a sweep of dead-pid leftovers for this target is
+ * done up front so the next run heals the last one.
  */
 export function writeFileAtomic(path: string, contents: string): void {
+	removeStaleTemps(dirname(path), `${basename(path)}.tmp-`);
 	const tmp = `${path}.tmp-${process.pid}`;
 	try {
 		writeFileSync(tmp, contents);

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -38,7 +38,7 @@ export function getBaseModelCachePath(
  * no such process, while `EPERM` means it exists but is owned by someone
  * else — still alive, so still not ours to clean up.
  */
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
 		return true;


### PR DESCRIPTION
## Description

writeFileAtomic creates a .tmp-<pid> file while writing and normally removes it in the finally block. The problem is that if the process gets killed with something like SIGKILL, the cleanup never runs, so the temp file is left behind in .nanotune/benchmarks/.

This PR adds cleanup for those leftover files:

- Clean up stale .tmp-<pid> files when nanotune starts.
- Clean up stale temp files before writeFileAtomic writes to the same path.
- Reuse the existing isProcessAlive check to make sure we only remove files from processes that are no longer running.
- Live process temp files are left untouched, so concurrent runs should be safe.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [x] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
