### PR TITLE
ci: adopt nc-review

### DIFF
--- a/.github/nc-review/rubric.md
+++ b/.github/nc-review/rubric.md
@@ -1,0 +1,106 @@
+# nc-review rubric — Nanotune
+
+This is the **project** half of the rubric: what Nanotune cares about. The
+reviewing method — how to read a diff against a base checkout, how to rate
+severity, what to emit — is the shared base rubric you were also given. Read
+both; where they disagree, this file wins.
+
+## What this project is, and why that changes review
+
+Nanotune is an interactive Ink TUI that wraps **MLX** for LoRA training and
+**llama.cpp** for GGUF conversion, quantization and inference. `AGENTS.md` is the
+architecture document and is authoritative.
+
+Two things follow from that and shape almost every review here:
+
+**It drives long, expensive, irreversible work.** A training run costs a user
+hours of their machine. A bug that corrupts a dataset, loses a checkpoint, or
+crashes at minute 90 does not cost a retry — it costs the run. Weigh data-loss
+and late-crash risks harder than you would in a library.
+
+**It is macOS on Apple Silicon only, and CI is not.** MLX has no fallback and
+only `macos-arm64` llama.cpp binaries ship. So the paths that matter most are
+the ones CI cannot execute, and "the tests pass" says correspondingly less here.
+When a diff touches the MLX or llama.cpp boundary, read it as though nothing
+downstream will catch a mistake — because nothing will.
+
+## Where the bugs actually are
+
+Every one of these has been fixed here. Check them first.
+
+### Dataset writes
+
+The dataset is the user's work. Bugs found in this area already: orphaned
+`.temp` files left behind by a crashed atomic write, a `validate` pass applying
+its fixes more than once per invocation, and write helpers that could omit
+`isEval` and silently mislabel a row.
+
+Any diff that writes `train.jsonl` or touches the atomic-write path should be
+read for: what happens if the process dies between write and rename, whether the
+operation is idempotent, and whether every helper that writes a row is forced to
+say which split it belongs to.
+
+### Subprocess boundaries
+
+MLX and llama.cpp are spawned. Review those call sites for arguments built by
+string concatenation from user input, missing timeouts, and exit codes that are
+not checked. An LLM-judge call went out unbounded until `--timeout` was added.
+
+### Secrets and environment expansion
+
+Env-var substitution once corrupted literal API keys by expanding something that
+should have been passed through. Treat any change to `env-substitution` or to
+how provider keys are read as security-relevant, and check the case where the
+value itself contains `$`.
+
+### Crashing the render
+
+Malformed `config.json` or `train.jsonl` used to take the Ink render down rather
+than being reported. A TUI that dies on bad input gives the user a stack trace
+where an error message belongs. Prefer a rendered error, and flag changes that
+let a parse failure escape into a component.
+
+### Ink and the event loop
+
+React here is Ink, not a browser: no DOM, no bundler. Synchronous work in a
+component blocks the terminal, and writing to stdout directly corrupts the
+render. Neither shows up in a unit test.
+
+### Numeric flags
+
+Unparseable numeric flags were accepted and became `NaN` downstream. Flag
+parsing that does not reject bad input is a finding.
+
+## Public contracts
+
+Breaking these is `blocking` without a changeset and a deliberate bump:
+
+- **The dataset format** — `train.jsonl` rows and the `isEval` split. Existing
+  projects on disk must keep working.
+- **`.nanotune/` project layout** and `config.json`'s schema.
+- **CLI commands and flags** across `init`, `data`, `train`, `export`,
+  `benchmark`, `judge`, `chat`, `status`.
+- **Exported types** in `src/types/`.
+
+## Tests
+
+Tests are colocated as `src/**/*.spec.ts` and `*.spec.tsx`.
+
+**Coverage here is 71.6% against the collective's 80% bar**, and the caller
+workflow pins the floor at 71 with fail-on-drop while the gap closes. Two
+consequences for review:
+
+- New code arriving without tests makes the gap worse, and the pin means it
+  cannot be repaid by someone else later without effort. Ask for tests on new
+  logic even when the overall gate is green.
+- A pinned floor is temporary, not the standard. Do not cite 71 as the bar.
+
+Judge whether a test would actually fail if the behaviour regressed. Given how
+much of this codebase cannot run in CI, a test that only asserts a function was
+called is close to worthless here.
+
+## Scope
+
+Contributions cluster in `src/lib` because that is the part that runs anywhere.
+That is fine. But a fix in `lib` for a problem that really lives at the MLX or
+llama.cpp boundary is treating the symptom — say so when you see it.

--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -1,0 +1,67 @@
+name: nc-review
+
+# Thin caller for the shared org workflow. The machinery lives in
+# Nano-Collective/.github — change it there and every repo picks it up on its
+# next run. What stays here is the trigger wiring and the rubric.
+#
+# The rubric is deliberately NOT shared. It is where a project says what it
+# cares about — its conventions, its test layout, the mistakes it keeps seeing.
+# Sharing it would produce reviews that read the same everywhere and land
+# nowhere. Same split as pr-checks: shared machinery, local judgement.
+#
+# Before adopting this in a repo you need two things:
+#
+#   1. `.github/nc-review/rubric.md` in this repository.
+#   2. MINIMAX_API_KEY readable here — set it once as an ORGANISATION secret
+#      with visibility "all". Organisation Actions secrets are available to
+#      public repositories on the Free plan (verified 2026-09-07), so there is
+#      no need to copy the key into each repo.
+#
+# Retire `copilot_code_review` from that repo's Review gates ruleset only once
+# this is live and producing verdicts — removing it earlier leaves the repo with
+# no automated review at all, which inverts decision Q7.
+
+on:
+  pull_request_target:
+    # On open only (decision Q8). Re-review is manual, via the comment trigger
+    # below — re-running on every push would burn tokens on work in progress.
+    types: [opened]
+    branches: [main]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
+
+concurrency:
+  # One review per PR. A /re-review while one is running queues behind it.
+  group: nc-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  nc-review:
+    uses: Nano-Collective/.github/.github/workflows/nc-review.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      # Only ever non-empty on workflow_dispatch, and that is deliberate.
+      # The shared workflow resolves the PR itself with
+      #   github.event.pull_request.number || github.event.issue.number || inputs.pr-number
+      # so pull_request_target and issue_comment are covered by the event, and
+      # this input is purely the manual-dispatch fallback. Do not duplicate that
+      # expression here — it would be the same logic in nine callers, drifting.
+      pr-number: ${{ inputs.pr_number }}
+      # AGENTS.md is this repo's architecture document.
+      architecture-doc: 'AGENTS.md'
+    secrets:
+      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}


### PR DESCRIPTION
Fourth repository onto the shared review workflow. **Two files**: the caller, and this project's own rubric — the reviewing method is fetched from [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github/blob/main/nc-review/rubric-base.md) at run time.

`architecture-doc` points at `AGENTS.md`.

## Why this rubric is not boilerplate

Two facts about Nanotune shape nearly every review here, and a reviewer arriving from another repo would have neither:

**It drives long, expensive, irreversible work.** A bug that corrupts a dataset or crashes at minute 90 of a training run does not cost a retry — it costs the run. Data-loss and late-crash risks are weighted harder than they would be in a library.

**It is macOS arm64 only, and CI is not.** MLX has no fallback and only `macos-arm64` llama.cpp binaries ship, so **the paths that matter most are the ones CI cannot execute**. "The tests pass" says materially less here, and the rubric says to read the MLX/llama.cpp boundary as though nothing downstream will catch a mistake — because nothing will.

## The named failure classes are all things fixed in this repo

- orphaned `.temp` files from a crashed atomic write (#160)
- `validate` applying its fixes more than once per invocation (#159)
- write helpers that could omit `isEval` and silently mislabel a row (#129)
- an unbounded LLM-judge call, before `--timeout` (#155)
- env expansion corrupting literal API keys (#156)
- malformed `config.json` / `train.jsonl` taking the Ink render down instead of being reported (#130)
- numeric flags accepted and becoming `NaN` downstream (#161)

## On the coverage pin

The caller pins the floor at **71** with fail-on-drop, against the collective's 80. The rubric records that this is **temporary and not the bar**, and asks for tests on new logic even when the gate is green — a pinned floor plus untested additions is exactly how a gap stops closing.

## Rollout note

**Copilot review stays on this repo** until nc-review is producing verdicts here — removing it first would leave the repo with no automated review at all, inverting Q7.

`pull_request_target` resolves the workflow from the **base** branch, so this PR will not be reviewed by it; the first PR opened after merge will.

The org `MINIMAX_API_KEY` is already set, so no secret work is needed here — verified on prompt-scrubber, which has no repo-level key.