### PR TITLE
ci: call the shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release to NPM and GitHub
 
+# Thin caller for the shared org workflow. Everything lives in
+# Nano-Collective/.github — change it there and every repo picks it up.
+#
+# Publishes only when package.json's version is ahead of npm, so merging the
+# Version Packages PR is what triggers a release. Nothing else does.
+
 on:
   push:
     branches: [main]
@@ -7,161 +13,17 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required for npm publish --provenance (OIDC build attestation).
   id-token: write
 
 jobs:
-  check-version:
-    runs-on: ubuntu-latest
-    outputs:
-      should-publish: ${{ steps.version-check.outputs.should-publish }}
-      package-version: ${{ steps.version-check.outputs.package-version }}
-      npm-version: ${{ steps.version-check.outputs.npm-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-
-      - name: Check version difference
-        id: version-check
-        run: |
-          # Get current package.json version
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "package-version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-
-          # Get latest NPM version (handle case where package doesn't exist yet)
-          NPM_VERSION=$(npm view @nanocollective/nanotune version 2>/dev/null || echo "0.0.0")
-          echo "npm-version=$NPM_VERSION" >> $GITHUB_OUTPUT
-
-          # Compare versions
-          if [ "$PACKAGE_VERSION" != "$NPM_VERSION" ]; then
-            echo "✅ New version detected: $PACKAGE_VERSION (current NPM: $NPM_VERSION)"
-            echo "should-publish=true" >> $GITHUB_OUTPUT
-          else
-            echo "ℹ️ No version change detected: $PACKAGE_VERSION"
-            echo "should-publish=false" >> $GITHUB_OUTPUT
-          fi
-
-  publish:
-    needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Semgrep
-        run: |
-          pip install semgrep
-
-      - name: Build project
-        run: pnpm build
-
-      - name: Run tests
-        run: pnpm test:all
-
-      - name: Verify build output
-        run: |
-          if [ ! -f "dist/cli.js" ]; then
-            echo "❌ Build failed: dist/cli.js not found"
-            exit 1
-          fi
-          echo "✅ Build successful: dist/cli.js exists"
-
-      - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ needs.check-version.outputs.package-version }}
-          release_name: Nanotune v${{ needs.check-version.outputs.package-version }}
-          body: |
-            ## What's Changed
-
-            See [CHANGELOG.md](https://github.com/Nano-Collective/nanotune/blob/main/CHANGELOG.md) for details.
-
-            ### Installation
-            ```bash
-            npm install -g @nanocollective/nanotune
-            ```
-
-            ### Quick Start
-            ```bash
-            nanotune init
-            nanotune data add
-            nanotune train
-            nanotune export
-            nanotune benchmark
-            ```
-
-            **Full Changelog**: https://github.com/Nano-Collective/nanotune/compare/v${{ needs.check-version.outputs.npm-version }}...v${{ needs.check-version.outputs.package-version }}
-          draft: false
-          prerelease: false
-
-      - name: Send Discord Notification
-        if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "🎉 New Release: Nanotune v${{ needs.check-version.outputs.package-version }}",
-                "description": "A new version of Nanotune has been released!\n\n[View the full changelog on GitHub](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.check-version.outputs.package-version }})",
-                "color": 5763719,
-                "fields": [
-                  {
-                    "name": "Version",
-                    "value": "v${{ needs.check-version.outputs.package-version }}",
-                    "inline": true
-                  },
-                  {
-                    "name": "Installation",
-                    "value": "`npm install -g @nanocollective/nanotune`",
-                    "inline": false
-                  }
-                ],
-                "footer": {
-                  "text": "GitHub Actions"
-                },
-                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%S.000Z)'",
-                "url": "https://github.com/${{ github.repository }}/releases/tag/v${{ needs.check-version.outputs.package-version }}"
-              }]
-            }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-  notify:
-    needs: [check-version, publish]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify result
-        run: |
-          if [ "${{ needs.check-version.outputs.should-publish }}" == "true" ]; then
-            if [ "${{ needs.publish.result }}" == "success" ]; then
-              echo "🎉 Successfully published @nanocollective/nanotune v${{ needs.check-version.outputs.package-version }} to NPM and created GitHub release!"
-            else
-              echo "❌ Failed to publish @nanocollective/nanotune v${{ needs.check-version.outputs.package-version }}"
-              exit 1
-            fi
-          else
-            echo "ℹ️ No new version to publish (current: ${{ needs.check-version.outputs.package-version }})"
-          fi
+  release:
+    uses: Nano-Collective/.github/.github/workflows/release.yml@main
+    with:
+      release-name: 'Nanotune'
+      # The bin entry; this package ships a CLI.
+      verify-files: 'dist/cli.js'
+      install-command: 'npm install -g {pkg}'
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
The machinery moves to [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github/blob/main/.github/workflows/release.yml). Six repos ran the same four jobs from files that had drifted to between 76 and 256 lines.

## What is parameterised

Only what actually varied: build and test scripts, the files the build must produce, the changelog script, the release display name, and the install line. **The npm package name is derived from `package.json`** rather than restated — that is how a copy ends up publishing under the wrong name after a rename.

## Two behaviours kept deliberate

- **`check-version` reads the full published version list**, not `npm view … version`. That call resolves the `latest` dist-tag, which pre-1.0 lags behind the newest prerelease — so an already-published version would read as new and the publish would fail on every push. The list makes it an exact membership test.
- **The Discord announcement cannot fail a release that already shipped.** Skipped when the webhook is unset, and it swallows its own errors.

## On risk

The version guard is what makes this safe: nothing publishes unless `package.json` is genuinely ahead of the registry. The failure mode of a mistake is **a release that does not happen** — loud and fixable — rather than one that ships the wrong thing.

I cannot test a real publish without cutting a release, so I verified what could be checked in isolation: prerelease tag detection across stable/alpha/beta/rc, the install-template substitution, and the already-published membership test. All correct. Already merged and running on get-md and prompt-scrubber.

`verify-files` names what this package actually ships, checked against its `main`/`bin` entries — an npm publish of an empty package succeeds silently, so that check is the one that matters.
