### PR TITLE
fix: make train/valid split crash-safe against interrupted writes

### DIFF
--- a/.changeset/atomic-train-valid-split.md
+++ b/.changeset/atomic-train-valid-split.md
@@ -1,0 +1,9 @@
+---
+"@nanocollective/nanotune": patch
+---
+
+Fix a crash-safety gap where an interrupted train/validation split could
+permanently lose the held-back validation examples. `saveTrainingData` now
+writes through the existing atomic file-write helper, and the split writes
+`valid.jsonl` before truncating `train.jsonl`, so an interruption between the
+two writes can at worst leave a recoverable duplicate — never a loss.

--- a/src/lib/data.spec.ts
+++ b/src/lib/data.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "ava";
 import type { TrainingExample } from "../types/index.js";
@@ -23,6 +23,7 @@ import {
   loadTrainingData,
   mergeEditedTurn,
   parseCSV,
+  saveTrainingData,
   splitTrainValidation,
   updateTrainingExample,
   validateTrainingData,
@@ -1181,6 +1182,57 @@ test.serial(
     const result = splitTrainValidation(0.1, 1);
     t.is(result.validCount, 1);
     t.is(result.trainCount, 1);
+  },
+);
+
+// ── splitTrainValidation crash-safety (#162) ──────────────────────────
+
+test.serial(
+  "splitTrainValidation leaves train.jsonl fully intact when the write to valid.jsonl fails",
+  (t) => {
+    seedExamples(10);
+
+    // Deterministic stand-in for the issue's repro (mkdir over valid.jsonl,
+    // then Ctrl+C between the two writes): occupy valid.jsonl's path with a
+    // non-empty directory so the atomic rename inside saveTrainingData
+    // reliably fails, the same way it does not to lose data.
+    const validPath = join(DATA_DIR, "valid.jsonl");
+    mkdirSync(validPath, { recursive: true });
+    writeFileSync(join(validPath, "keep.txt"), "keep");
+
+    t.throws(() => splitTrainValidation(0.1, 1));
+
+    // valid.jsonl is written before train.jsonl is touched, so the failed
+    // first write must leave every original example still in train.jsonl —
+    // nothing removed, nothing held only in memory.
+    t.is(countExamples(false), 10);
+    const remaining = loadTrainingData(false)
+      .map((ex) => ex.messages[1].content)
+      .sort();
+    t.deepEqual(
+      remaining,
+      Array.from({ length: 10 }, (_, i) => `q${i}`).sort(),
+    );
+  },
+);
+
+test.serial(
+  "saveTrainingData leaves no temp file behind when the underlying write fails",
+  (t) => {
+    seedExamples(1);
+
+    const trainPath = join(DATA_DIR, "train.jsonl");
+    rmSync(trainPath, { force: true });
+    mkdirSync(trainPath, { recursive: true });
+    writeFileSync(join(trainPath, "keep.txt"), "keep");
+
+    t.throws(() => saveTrainingData([], false));
+
+    // The temp file created by writeFileAtomic must be cleaned up even
+    // though the rename never landed - no `train.jsonl.tmp-*` sibling left
+    // behind in the data directory.
+    const entries = readdirSync(DATA_DIR);
+    t.false(entries.some((name) => name.startsWith("train.jsonl.tmp-")));
   },
 );
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import {join} from 'node:path';
 import type {ChatMessage, TrainingExample} from '../types/index.js';
-import {getDataDir} from './config.js';
+import {getDataDir, writeFileAtomic} from './config.js';
 
 function ensureDataDir(): void {
 	const dataDir = getDataDir();
@@ -94,7 +94,7 @@ export function saveTrainingData(
 	ensureDataDir();
 	const path = isEval ? getEvalDataPath() : getTrainDataPath();
 	const content = `${examples.map(ex => JSON.stringify(ex)).join('\n')}\n`;
-	writeFileSync(path, content);
+	writeFileAtomic(path, content);
 }
 
 export function deleteExample(index: number, isEval = false): void {
@@ -787,9 +787,13 @@ export function splitTrainValidation(
 	const trainExamples = shuffled.slice(0, trainCount);
 	const validExamples = shuffled.slice(trainCount);
 
-	// Save both files
-	saveTrainingData(trainExamples, false);
+	// Write valid.jsonl before truncating train.jsonl. Each write is atomic
+	// (writeFileAtomic), so the only interruption window left is between the
+	// two calls - and with this order that window's worst case is both files
+	// temporarily containing the validation examples (a recoverable
+	// duplicate), never train.jsonl losing them before they land anywhere.
 	saveTrainingData(validExamples, true);
+	saveTrainingData(trainExamples, false);
 
 	return {trainCount, validCount};
 }


### PR DESCRIPTION
Fixes #162

## Description

`saveTrainingData` (`src/lib/data.ts`) now writes through the existing `writeFileAtomic` helper (temp-write + rename) instead of a bare `writeFileSync`, closing the truncate-then-write window on every dataset write. `splitTrainValidation` now writes `valid.jsonl` *before* truncating `train.jsonl`, so an interruption between the two calls can at worst leave a recoverable duplicate never the silent loss described in #162.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)