### PR TITLE
fix: reject empty strings in acceptable as vacuously-true matches

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.9'
-  js-yaml: ^3.15.1
+  js-yaml: ^3.15.2
   lodash: '>=4.17.24'
   minimatch: '>=10.2.3'
   picomatch: '>=4.0.4'
@@ -1372,8 +1372,8 @@ packages:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
   json-schema@0.4.0:
@@ -2955,7 +2955,7 @@ snapshots:
 
   js-string-escape@1.0.1: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3240,7 +3240,7 @@ snapshots:
   supertap@3.0.1:
     dependencies:
       indent-string: 5.0.0
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       serialize-error: 7.0.1
       strip-ansi: 7.2.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ allowBuilds:
 # --audit-level=high` (the Package Audit CI job) stays green.
 overrides:
   brace-expansion: '>=5.0.9'
-  js-yaml: ^3.15.1
+  js-yaml: ^3.15.2
   lodash: '>=4.17.24'
   minimatch: '>=10.2.3'
   picomatch: '>=4.0.4'

--- a/src/commands/benchmark.tsx
+++ b/src/commands/benchmark.tsx
@@ -470,6 +470,12 @@ export function BenchmarkCommand({options}: Props) {
 					setStatus('error');
 					return;
 				}
+
+				if (test.acceptable?.some(answer => answer.trim() === '')) {
+					setError(`Test #${test.id}: "acceptable" contains an empty string.`);
+					setStatus('error');
+					return;
+				}
 			}
 
 			let serverOptions: ServerOptions;

--- a/src/lib/benchmark-match.spec.ts
+++ b/src/lib/benchmark-match.spec.ts
@@ -157,3 +157,52 @@ test("checkPass contains is quote-sensitive", (t) => {
   t.false(checkPass(["'single'"], 'wrapped in "single" here', "contains").passed);
   t.true(checkPass(["'single'"], "wrapped in 'single' here", "contains").passed);
 });
+
+// ── empty string in acceptable (regression: issue #164) ────────────────
+// An empty string is vacuously matched by includes('')/startsWith('') and
+// must not be treated as a matchable answer under any mode.
+
+test("checkPass contains rejects an empty acceptable answer regardless of actual", (t) => {
+  const result = checkPass([""], "anything at all", "contains");
+  t.false(result.passed);
+  t.is(result.matchedAnswer, null);
+  t.is(result.matchType, null);
+});
+
+test("checkPass startsWith rejects an empty acceptable answer regardless of actual", (t) => {
+  const result = checkPass([""], "anything at all", "startsWith");
+  t.false(result.passed);
+  t.is(result.matchedAnswer, null);
+  t.is(result.matchType, null);
+});
+
+test("checkPass partial rejects an empty acceptable answer regardless of actual", (t) => {
+  const result = checkPass([""], "anything at all", "partial");
+  t.false(result.passed);
+  t.is(result.matchedAnswer, null);
+  t.is(result.matchType, null);
+});
+
+test("checkPass exact rejects an empty acceptable answer even against empty actual", (t) => {
+  t.false(checkPass([""], "", "exact").passed);
+});
+
+test("checkPass semantic rejects an empty acceptable answer even against empty actual", (t) => {
+  t.false(checkPass([""], "", "semantic").passed);
+});
+
+test("checkPass semantic rejects an empty acceptable answer against a colon-led actual", (t) => {
+  // Without the guard, '' + ':' delimiter branch would match any actual
+  // starting with ':'.
+  t.false(checkPass([""], ": foo", "semantic").passed);
+});
+
+test("checkPass skips a blank acceptable entry and still matches a later real one", (t) => {
+  const result = checkPass(["", "ls -la"], "ls -la", "contains");
+  t.true(result.passed);
+  t.is(result.matchedAnswer, "ls -la");
+});
+
+test("checkPass treats a whitespace-only acceptable answer as empty", (t) => {
+  t.false(checkPass(["   "], "anything at all", "contains").passed);
+});

--- a/src/lib/benchmark-match.ts
+++ b/src/lib/benchmark-match.ts
@@ -45,6 +45,14 @@ export function checkPass(
 		const expectedProcessed = processText(expected);
 		const expectedNormalized = normalizeText(expectedProcessed);
 
+		// An empty expected answer is not a matchable answer: contains/
+		// startsWith/partial (and the semantic delimiter branch) are all
+		// vacuously true against '', which would make the test pass no
+		// matter what the model produced.
+		if (expectedNormalized === '') {
+			continue;
+		}
+
 		switch (mode) {
 			case 'exact': {
 				if (actualProcessed === expectedProcessed) {


### PR DESCRIPTION
Fixes #164

## Description

`checkPass` (src/lib/benchmark-match.ts) now skips any `acceptable` entry
that normalizes to an empty string before it reaches the mode switch 
one guard covers `contains`, `startsWith`, `partial`, and the `semantic`
`:`-delimiter edge case uniformly. Dataset loading in
src/commands/benchmark.tsx now rejects a test whose `acceptable` array
contains a blank/whitespace-only string with
`Test #N: "acceptable" contains an empty string.`, next to the existing
prompt/messages check, so a bad `tests.json` fails loudly instead of
quietly inflating the pass rate.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully) with two pre-existing, environment-only exceptions verified unrelated to this change (see PR comment/description): 4 Windows-only test failures (NTFS permission bits, EBUSY rmdir) present identically on the base branch, and a `js-yaml` dev-dependency audit finding via `ava`'s toolchain. `lint`, `types`, `knip`, and `semgrep` are all clean.
- [x] New tests added for new functionality (if applicable) — 8 regression tests in `benchmark-match.spec.ts` covering the empty-string case for every match mode, plus a case confirming a blank entry doesn't shadow a real match later in the same array.

### Manual Testing

- [ ] Tested `nanotune init`
- [ ] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

## Checklist

- [ ] Code follows project style guidelines (`pnpm format`)- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)