### PR TITLE
fix: detach the training abort listener when a run ends

### DIFF
--- a/.changeset/detach-abort-listener-after-training.md
+++ b/.changeset/detach-abort-listener-after-training.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanotune": patch
+---
+
+Detach the training `abort` listener once a run finishes, so aborting a reused signal later no longer sends SIGINT to a closed subprocess.

--- a/src/lib/mlx.spec.ts
+++ b/src/lib/mlx.spec.ts
@@ -211,8 +211,56 @@ test("stopOnAbort signals only once", (t) => {
 
 test("stopOnAbort without a signal never touches the subprocess", (t) => {
   const { subprocess, signals } = fakeSubprocess();
-  stopOnAbort(subprocess, undefined);
+  const detach = stopOnAbort(subprocess, undefined);
+  detach();
   t.deepEqual(signals, []);
+});
+
+test("stopOnAbort detach stops a later abort from signalling a dead process", (t) => {
+  // A caller-owned signal outlives the run: once training is over, aborting it
+  // must not SIGINT a closed subprocess whose PID may have been recycled.
+  const { subprocess, signals } = fakeSubprocess();
+  const controller = new AbortController();
+  const detach = stopOnAbort(subprocess, controller.signal);
+
+  detach();
+  controller.abort();
+
+  t.deepEqual(signals, []);
+});
+
+test("stopOnAbort detach is safe to call twice", (t) => {
+  const { subprocess, signals } = fakeSubprocess();
+  const controller = new AbortController();
+  const detach = stopOnAbort(subprocess, controller.signal);
+
+  detach();
+  detach();
+  controller.abort();
+
+  t.deepEqual(signals, []);
+});
+
+test("stopOnAbort detach after an abort leaves the stop intact", (t) => {
+  const { subprocess, signals } = fakeSubprocess();
+  const controller = new AbortController();
+  const detach = stopOnAbort(subprocess, controller.signal);
+
+  controller.abort();
+  detach();
+
+  t.deepEqual(signals, ["SIGINT"]);
+});
+
+test("stopOnAbort detach for an already-aborted signal is a no-op", (t) => {
+  const { subprocess, signals } = fakeSubprocess();
+  const controller = new AbortController();
+  controller.abort();
+
+  const detach = stopOnAbort(subprocess, controller.signal);
+  detach();
+
+  t.deepEqual(signals, ["SIGINT"]);
 });
 
 test("stopOnAbort terminates a real running child process", async (t) => {

--- a/src/lib/mlx.ts
+++ b/src/lib/mlx.ts
@@ -383,6 +383,7 @@ export async function* runTraining(
 	// config. Directory creation happens inside the try so a failed write still
 	// gets cleaned up in the finally below rather than leaking a temp dir.
 	let loraConfigDir: string | null = null;
+	let detachAbort: (() => void) | null = null;
 	try {
 		let loraConfigPath: string | undefined;
 		if (needsLoraConfig(options.fineTuneType)) {
@@ -408,7 +409,7 @@ export async function* runTraining(
 			},
 		);
 
-		stopOnAbort(subprocess, options.signal);
+		detachAbort = stopOnAbort(subprocess, options.signal);
 
 		const stdout = subprocess.stdout;
 		const stderr = subprocess.stderr;
@@ -478,6 +479,7 @@ export async function* runTraining(
 			throw err;
 		}
 	} finally {
+		detachAbort?.();
 		if (loraConfigDir) {
 			rmSync(loraConfigDir, {recursive: true, force: true});
 		}
@@ -505,21 +507,25 @@ export async function fuseAdapters(
  * Stop `subprocess` as soon as `signal` aborts. Split out from `runTraining`
  * so the wiring — including a signal that is already aborted, which never
  * fires an `abort` event — is testable without spawning a trainer.
+ *
+ * Returns a detach function. Callers must invoke it once the run is over:
+ * a caller-owned signal outlives the subprocess, and a listener left attached
+ * would signal a dead (or PID-recycled) process on a later abort.
  */
 export function stopOnAbort(
 	subprocess: ResultPromise,
 	signal?: AbortSignal,
-): void {
+): () => void {
 	if (!signal) {
-		return;
+		return () => {};
 	}
 	if (signal.aborted) {
 		abortTraining(subprocess);
-		return;
+		return () => {};
 	}
-	signal.addEventListener('abort', () => abortTraining(subprocess), {
-		once: true,
-	});
+	const onAbort = () => abortTraining(subprocess);
+	signal.addEventListener('abort', onAbort, {once: true});
+	return () => signal.removeEventListener('abort', onAbort);
 }
 
 export function abortTraining(subprocess: ResultPromise): void {


### PR DESCRIPTION
## Description

Fixes #152. `stopOnAbort` added an `abort` listener to the `AbortSignal` but never
removed it when a training run ended normally. The `{once: true}` option only
removes a listener after it fires, and on a successful run it never fires. Since
the signal belongs to the caller and lives longer than the run, aborting it later
made the old listener call `kill('SIGINT')` on a process that was already gone —
and if the OS had reused that PID, on some other process. `stopOnAbort` now
returns a detach function, and `runTraining` calls it in the `finally` block, so
the listener is removed on every exit path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

Lint, format, types, knip, semgrep and all 531 AVA tests pass. `pnpm audit` fails
on a pre-existing advisory in a dev dependency (`ava > supertap > js-yaml`), which
this PR does not touch.

Four regression tests were added in `src/lib/mlx.spec.ts`: a late abort after
detach sends nothing, calling detach twice is safe, detach after a real abort
still keeps the SIGINT, and detach on an already-aborted signal does nothing.
All four fail on the old code.

### Manual Testing

- [ ] Tested `nanotune init`
- [ ] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

I do not have an Apple Silicon Mac, so I could not run the MLX commands. The fix
was checked with a script that spawns a real child process, lets it exit, then
aborts the signal. Before the fix the dead process is sent SIGINT; after it,
nothing happens.

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

`stopOnAbort` now returns a value instead of `void`. It is an internal helper with
one caller, and ignoring the return value still behaves as before, so nothing
breaks. A patch changeset is included.