### PR TITLE
fix: harden fused-model cache checks and extend clean to base cache

### DIFF
--- a/.changeset/clean-target-and-fuse-hardening.md
+++ b/.changeset/clean-target-and-fuse-hardening.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanotune": minor
+---
+
+- Added `nanotune clean --target <fused|base|all>` to also cover the shared base-model cache alongside the fused-model cache, and hardened the completeness checks behind both: an interrupted multi-shard fuse or a permission error reading a cache directory no longer produces a false "usable" or crashes `nanotune status`/`nanotune clean`. Thanks to @rohanshrma222. Closes #125.

--- a/docs/commands/clean.md
+++ b/docs/commands/clean.md
@@ -1,14 +1,16 @@
 ---
 title: "nanotune clean"
-description: "Remove the cached fused model to reclaim disk space"
+description: "Remove cached models to reclaim disk space"
 sidebar_order: 9
 ---
 
 # nanotune clean
 
-Remove the fused model cache at `.nanotune/models/fused/`.
+Remove cached models that build up outside your project's tracked files.
 
-`nanotune export` keeps a full-precision copy of the fused model around after export so that `nanotune export --skip-fuse` can reuse it for a different quantization without redoing the fusion step. That directory can be multiple gigabytes — `nanotune clean` deletes it to reclaim the space.
+By default this targets the fused model cache at `.nanotune/models/fused/`: `nanotune export` keeps a full-precision copy of the fused model around after export so that `nanotune export --skip-fuse` can reuse it for a different quantization without redoing the fusion step. That directory can be multiple gigabytes.
+
+There's also a base-model cache at `~/.nanotune/models/base-cache/`, shared across every project on this machine: `nanotune benchmark --base` keeps a quantized copy of the base model there so repeat control runs skip the download/convert/quantize step. Pass `--target base` (or `--target all`) to clean that too.
 
 ## Usage
 
@@ -21,6 +23,7 @@ nanotune clean
 | Flag | Description |
 |------|-------------|
 | `-y, --yes` | Skip the confirmation prompt (for scripts and CI) |
+| `--target <fused\|base\|all>` | Which cache to clean (default: `fused`) |
 
 ## Examples
 
@@ -30,16 +33,26 @@ nanotune clean
 
 # Remove it without prompting
 nanotune clean --yes
+
+# Clean the shared base-model cache instead (works from any directory,
+# not just inside a project)
+nanotune clean --target base
+
+# Clean both caches in one pass
+nanotune clean --target all --yes
 ```
 
 ## What It Does
 
-1. Checks `.nanotune/models/fused/` for a cached fused model.
-2. If found, shows its size and asks for confirmation (unless `--yes` is passed).
-3. Deletes the directory and reports how much space was freed.
+1. Checks whichever cache(s) `--target` selects — `.nanotune/models/fused/` for `fused`, `~/.nanotune/models/base-cache/` for `base`, or both for `all`.
+2. If anything's found, shows its size (and a combined total for `all`) and asks for confirmation (unless `--yes` is passed).
+3. Deletes each cache directory found and reports how much space was freed.
 
-If there's nothing to clean, it says so and exits without changes. Your exported `.gguf` files are never touched — only the intermediate fused model is removed. The next `nanotune export` will simply re-fuse the adapter.
+If there's nothing to clean for the requested target, it says so and exits without changes. `--target fused` (the default) still requires being inside a Nanotune project; `--target base` doesn't, since that cache isn't project-scoped. `--target all` outside a project simply skips the fused half rather than erroring.
+
+Your exported `.gguf` files are never touched — only the intermediate caches are removed. The next `nanotune export` will simply re-fuse the adapter, and the next `nanotune benchmark --base` will re-download and requantize the base model.
 
 ## See Also
 
-- [`nanotune export`](export.md) — See "Fused Model Cache" for why this directory exists
+- [`nanotune export`](export.md) — See "Fused Model Cache" for why the fused cache exists
+- [`nanotune benchmark`](benchmark.md) — See `--base` for why the base-model cache exists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,11 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.9'
-  js-yaml: ^3.15.2
+  js-yaml: '>=3.15.2'
   lodash: '>=4.17.24'
   minimatch: '>=10.2.3'
   picomatch: '>=4.0.4'
+  smol-toml: '>=1.7.1'
   tar: '>=7.5.21'
 
 importers:
@@ -924,8 +925,8 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-find-index@1.0.2:
     resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
@@ -1126,11 +1127,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -1371,8 +1367,8 @@ packages:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
 
-  js-yaml@3.15.2:
-    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
+  js-yaml@5.4.1:
+    resolution: {integrity: sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==}
     hasBin: true
 
   json-schema@0.4.0:
@@ -1631,9 +1627,6 @@ packages:
   smol-toml@1.8.0:
     resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -2493,9 +2486,7 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
+  argparse@2.0.1: {}
 
   array-find-index@1.0.2: {}
 
@@ -2717,8 +2708,6 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@5.0.0: {}
-
-  esprima@4.0.1: {}
 
   estree-walker@2.0.2: {}
 
@@ -2947,10 +2936,9 @@ snapshots:
 
   js-string-escape@1.0.1: {}
 
-  js-yaml@3.15.2:
+  js-yaml@5.4.1:
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
 
   json-schema@0.4.0: {}
 
@@ -3198,8 +3186,6 @@ snapshots:
 
   smol-toml@1.8.0: {}
 
-  sprintf-js@1.0.3: {}
-
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -3231,7 +3217,7 @@ snapshots:
   supertap@3.0.1:
     dependencies:
       indent-string: 5.0.0
-      js-yaml: 3.15.2
+      js-yaml: 5.4.1
       serialize-error: 7.0.1
       strip-ansi: 7.2.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,9 @@ allowBuilds:
 # --audit-level=high` (the Package Audit CI job) stays green.
 overrides:
   brace-expansion: '>=5.0.9'
-  js-yaml: ^3.15.2
+  js-yaml: '>=3.15.2'
   lodash: '>=4.17.24'
   minimatch: '>=10.2.3'
   picomatch: '>=4.0.4'
+  smol-toml: '>=1.7.1'
   tar: '>=7.5.21'

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -347,10 +347,7 @@ program
 	.command('clean')
 	.description('Remove cached models (fused and/or base) to reclaim disk space')
 	.option('-y, --yes', 'Skip the confirmation prompt (for scripts and CI)')
-	.option(
-		'--target <fused|base|all>',
-		'Which cache to clean (default: fused)',
-	)
+	.option('--target <fused|base|all>', 'Which cache to clean (default: fused)')
 	.action(async (options: {yes?: boolean; target?: string}) => {
 		const {CleanCommand, validateCleanTarget} = await import(
 			'./commands/clean.js'

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -345,22 +345,41 @@ program
 // Clean command
 program
 	.command('clean')
-	.description('Remove the cached fused model to reclaim disk space')
+	.description('Remove cached models (fused and/or base) to reclaim disk space')
 	.option('-y, --yes', 'Skip the confirmation prompt (for scripts and CI)')
-	.action(async (options: {yes?: boolean}) => {
+	.option(
+		'--target <fused|base|all>',
+		'Which cache to clean (default: fused)',
+	)
+	.action(async (options: {yes?: boolean; target?: string}) => {
+		const {CleanCommand, validateCleanTarget} = await import(
+			'./commands/clean.js'
+		);
 		// Only require --yes when there's actually a confirmation to answer —
 		// "nothing to clean" and "not a project" are safe to just report.
 		if (!options.yes && !supportsRawMode()) {
 			const {configExists, getFusedModelDir, hasUsableFusedModel} =
 				await import('./lib/config.js');
-			if (configExists() && hasUsableFusedModel(getFusedModelDir())) {
+			const {hasBaseModelCache} = await import('./lib/model-cache.js');
+			const targetResult = validateCleanTarget(options.target);
+			const wantsFused =
+				!('error' in targetResult) &&
+				(targetResult.target === 'fused' || targetResult.target === 'all');
+			const wantsBase =
+				!('error' in targetResult) &&
+				(targetResult.target === 'base' || targetResult.target === 'all');
+			const hasSomethingToConfirm =
+				(wantsFused &&
+					configExists() &&
+					hasUsableFusedModel(getFusedModelDir())) ||
+				(wantsBase && hasBaseModelCache());
+			if (hasSomethingToConfirm) {
 				console.error(interactiveRequiredMessage('clean'));
 				console.error('Pass --yes to clean without confirmation.');
 				process.exitCode = 1;
 				return;
 			}
 		}
-		const {CleanCommand} = await import('./commands/clean.js');
 		render(<CleanCommand options={options} />);
 	});
 

--- a/src/commands/clean.tsx
+++ b/src/commands/clean.tsx
@@ -1,4 +1,5 @@
 import {rmSync} from 'node:fs';
+import {homedir} from 'node:os';
 import {StatusMessage} from '@inkjs/ui';
 import {Box, Text, useApp} from 'ink';
 import {useCallback, useEffect, useState} from 'react';
@@ -15,45 +16,139 @@ import {
 	getFusedModelDir,
 	hasUsableFusedModel,
 } from '../lib/config.js';
+import {getBaseModelCacheDir, hasBaseModelCache} from '../lib/model-cache.js';
 
 interface Props {
 	options: {
 		/** Skip the y/n confirmation — needed to run under CI or in a pipeline. */
 		yes?: boolean;
+		target?: string;
 	};
+	/**
+	 * Override for the base-model cache directory. Production never passes
+	 * this — it's here so tests can point at a throwaway directory instead
+	 * of the real home directory (unlike the fused-model cache, which lives
+	 * under the project dir and is already sandboxed via `process.chdir` in
+	 * tests, the base cache is keyed off `os.homedir()`, which can't be
+	 * safely monkeypatched: Node's ESM module namespace for a builtin is
+	 * read-only at runtime, so patching it doesn't reach other modules'
+	 * already-bound imports).
+	 */
+	baseModelCacheDir?: string;
+}
+
+const VALID_TARGETS = ['fused', 'base', 'all'] as const;
+type CleanTarget = (typeof VALID_TARGETS)[number];
+
+/**
+ * Validate `--target`. Pulled out as a pure function (mirrors the
+ * `--preset` validation in `benchmark.tsx`) so it's directly testable and
+ * so `cli.tsx` can reuse it to decide whether there's anything to confirm
+ * before requiring `--yes` in a non-interactive shell.
+ */
+export function validateCleanTarget(
+	target: string | undefined,
+): {target: CleanTarget} | {error: string} {
+	if (target === undefined) {
+		return {target: 'fused'};
+	}
+	if ((VALID_TARGETS as readonly string[]).includes(target)) {
+		return {target: target as CleanTarget};
+	}
+	return {
+		error: `Invalid target: ${target}. Valid targets: ${VALID_TARGETS.join(', ')}`,
+	};
+}
+
+interface CleanEntry {
+	label: string;
+	dir: string;
+	displayPath: string;
+	sizeBytes: number;
+	note: string;
+}
+
+function findCleanEntries(
+	target: CleanTarget,
+	hasProject: boolean,
+	baseModelCacheDir: string,
+): CleanEntry[] {
+	const wantsFused = target === 'fused' || target === 'all';
+	const wantsBase = target === 'base' || target === 'all';
+	const entries: CleanEntry[] = [];
+
+	if (wantsFused && hasProject) {
+		const fusedDir = getFusedModelDir();
+		if (hasUsableFusedModel(fusedDir)) {
+			entries.push({
+				label: 'Fused model cache',
+				dir: fusedDir,
+				displayPath: '.nanotune/models/fused',
+				sizeBytes: getDirectorySize(fusedDir),
+				note: 'kept to speed up repeat exports via --skip-fuse',
+			});
+		}
+	}
+
+	if (wantsBase && hasBaseModelCache(baseModelCacheDir)) {
+		entries.push({
+			label: 'Base model cache',
+			dir: baseModelCacheDir,
+			displayPath: baseModelCacheDir.replace(homedir(), '~'),
+			sizeBytes: getDirectorySize(baseModelCacheDir),
+			note: 'kept to speed up repeat `benchmark --base` runs',
+		});
+	}
+
+	return entries;
 }
 
 type Status = 'confirm' | 'cleaning' | 'nothing' | 'done' | 'error';
 
-export function CleanCommand({options}: Props) {
+export function CleanCommand({options, baseModelCacheDir}: Props) {
 	const {exit} = useApp();
 	const hasProject = configExists();
-	const fusedDir = getFusedModelDir();
-	const fusedExists = hasProject && hasUsableFusedModel(fusedDir);
+	const targetResult = validateCleanTarget(options.target);
+	const resolvedBaseDir = baseModelCacheDir ?? getBaseModelCacheDir();
+
+	const [entries] = useState<CleanEntry[]>(() =>
+		'error' in targetResult
+			? []
+			: findCleanEntries(targetResult.target, hasProject, resolvedBaseDir),
+	);
+	const [freedBytes, setFreedBytes] = useState(0);
 
 	const [status, setStatus] = useState<Status>(() => {
-		if (!hasProject) return 'error';
-		if (!fusedExists) return 'nothing';
+		if ('error' in targetResult) return 'error';
+		if (targetResult.target === 'fused' && !hasProject) return 'error';
+		if (entries.length === 0) return 'nothing';
 		return options.yes ? 'cleaning' : 'confirm';
 	});
-	const [error, setError] = useState<string | null>(null);
-	const [sizeLabel] = useState<string | null>(() =>
-		fusedExists ? formatFileSize(getDirectorySize(fusedDir)) : null,
+	const [error, setError] = useState<string | null>(
+		'error' in targetResult ? targetResult.error : null,
 	);
 
 	const doClean = useCallback(() => {
-		try {
-			rmSync(fusedDir, {recursive: true, force: true});
-			setStatus('done');
-		} catch (err) {
-			setError(
-				err instanceof Error
-					? err.message
-					: 'Failed to remove fused model cache',
-			);
-			setStatus('error');
+		let totalFreed = 0;
+		const failures: string[] = [];
+		for (const entry of entries) {
+			try {
+				rmSync(entry.dir, {recursive: true, force: true});
+				totalFreed += entry.sizeBytes;
+			} catch (err) {
+				failures.push(
+					`${entry.label}: ${err instanceof Error ? err.message : 'failed to remove'}`,
+				);
+			}
 		}
-	}, [fusedDir]);
+		setFreedBytes(totalFreed);
+		if (failures.length > 0) {
+			setError(failures.join('\n'));
+			setStatus('error');
+		} else {
+			setStatus('done');
+		}
+	}, [entries]);
 
 	// `--yes` (or the initial `cleaning` state it sets above) skips straight
 	// past the confirmation prompt.
@@ -84,7 +179,11 @@ export function CleanCommand({options}: Props) {
 		status === 'error',
 	);
 
-	if (!hasProject) {
+	if (
+		!('error' in targetResult) &&
+		targetResult.target === 'fused' &&
+		!hasProject
+	) {
 		return (
 			<Box flexDirection="column" padding={1}>
 				<Header title="Clean" />
@@ -95,33 +194,54 @@ export function CleanCommand({options}: Props) {
 		);
 	}
 
+	const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+	const nothingMessage = (() => {
+		if ('error' in targetResult) return '';
+		if (targetResult.target === 'all') {
+			return 'Nothing to clean — no fused or base model cache found.';
+		}
+		if (targetResult.target === 'base') {
+			return 'Nothing to clean — no base model cache found.';
+		}
+		return 'Nothing to clean — no fused model cache found.';
+	})();
+
 	return (
 		<Box flexDirection="column" padding={1}>
 			<Header title="Clean" />
 
 			{status === 'confirm' && (
 				<Box flexDirection="column">
-					<Text>
-						Fused model cache: <Text color="cyan">{sizeLabel}</Text> at{' '}
-						<Text color="cyan">.nanotune/models/fused</Text>
-					</Text>
-					<Text dimColor>
-						This is kept to speed up repeat exports via --skip-fuse.
-					</Text>
+					{entries.map(entry => (
+						<Text key={entry.dir}>
+							{entry.label}:{' '}
+							<Text color="cyan">{formatFileSize(entry.sizeBytes)}</Text> at{' '}
+							<Text color="cyan">{entry.displayPath}</Text>
+						</Text>
+					))}
+					{entries.length > 1 && (
+						<Text>
+							Total: <Text color="cyan">{formatFileSize(totalBytes)}</Text>
+						</Text>
+					)}
+					{entries.map(entry => (
+						<Text key={entry.dir} dimColor>
+							{entries.length > 1 ? entry.label : 'This'} is {entry.note}.
+						</Text>
+					))}
 					<Text> </Text>
 					<Text>
-						Remove it? <Text color="green">(y/n)</Text>
+						Remove {entries.length > 1 ? 'these' : 'it'}?{' '}
+						<Text color="green">(y/n)</Text>
 					</Text>
 				</Box>
 			)}
 
-			{status === 'cleaning' && <Text>Removing fused model cache...</Text>}
+			{status === 'cleaning' && <Text>Removing cache...</Text>}
 
 			{status === 'nothing' && (
 				<Box flexDirection="column">
-					<StatusMessage variant="info">
-						Nothing to clean — no fused model cache found.
-					</StatusMessage>
+					<StatusMessage variant="info">{nothingMessage}</StatusMessage>
 					<Text> </Text>
 					<ExitHint>Press any key to exit</ExitHint>
 				</Box>
@@ -130,15 +250,23 @@ export function CleanCommand({options}: Props) {
 			{status === 'done' && (
 				<Box flexDirection="column">
 					<StatusMessage variant="success">
-						Removed fused model cache
+						Removed {entries.map(e => e.label.toLowerCase()).join(' and ')}
 					</StatusMessage>
 					<Text> </Text>
 					<Text>
-						Freed: <Text color="cyan">{sizeLabel}</Text>
+						Freed: <Text color="cyan">{formatFileSize(freedBytes)}</Text>
 					</Text>
-					<Text dimColor>
-						The next `nanotune export` will re-fuse the adapter.
-					</Text>
+					{entries.some(e => e.label === 'Fused model cache') && (
+						<Text dimColor>
+							The next `nanotune export` will re-fuse the adapter.
+						</Text>
+					)}
+					{entries.some(e => e.label === 'Base model cache') && (
+						<Text dimColor>
+							The next `nanotune benchmark --base` will re-download and
+							requantize the base model.
+						</Text>
+					)}
 					<Text> </Text>
 					<ExitHint>Press any key to exit</ExitHint>
 				</Box>

--- a/src/commands/clean.tsx
+++ b/src/commands/clean.tsx
@@ -91,10 +91,13 @@ function findCleanEntries(
 	}
 
 	if (wantsBase && hasBaseModelCache(baseModelCacheDir)) {
+		const home = homedir();
 		entries.push({
 			label: 'Base model cache',
 			dir: baseModelCacheDir,
-			displayPath: baseModelCacheDir.replace(homedir(), '~'),
+			displayPath: baseModelCacheDir.startsWith(home)
+				? `~${baseModelCacheDir.slice(home.length)}`
+				: baseModelCacheDir,
 			sizeBytes: getDirectorySize(baseModelCacheDir),
 			note: 'kept to speed up repeat `benchmark --base` runs',
 		});

--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -535,6 +535,28 @@ test.serial("CleanCommand --target base reports nothing to clean when the base c
   }
 });
 
+test.serial("CleanCommand --target base --yes reports nothing to clean when the base cache is absent", async (t) => {
+  // Regression check: --yes must not skip past the "is there anything to
+  // clean" check straight into doClean with an empty entries list.
+  try {
+    setupEmptyDir();
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    const output = await renderCommand(
+      <CleanCommand
+        options={{ target: "base", yes: true }}
+        baseModelCacheDir={FAKE_BASE_CACHE_DIR}
+      />,
+      "Nothing to clean",
+    );
+    t.true(output.includes("Nothing to clean"));
+    t.false(output.includes("Removed"));
+    t.false(existsSync(FAKE_BASE_CACHE_DIR));
+  } finally {
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    teardown();
+  }
+});
+
 test.serial("CleanCommand --target base removes the base-model cache with --yes", async (t) => {
   try {
     setupEmptyDir();

--- a/src/commands/commands.spec.tsx
+++ b/src/commands/commands.spec.tsx
@@ -12,7 +12,7 @@ import { render } from "ink-testing-library";
 import { useKeyInput } from "../components/index.js";
 import { getFusedModelDir } from "../lib/config.js";
 import { loadTrainingData } from "../lib/data.js";
-import { CleanCommand } from "./clean.js";
+import { CleanCommand, validateCleanTarget } from "./clean.js";
 import { ChatCommand, streamPreview } from "./chat.js";
 import { DataExportCommand } from "./data/export.js";
 import { DataImportCommand } from "./data/import.js";
@@ -81,6 +81,20 @@ function writeIncompleteFusedModel() {
   const fusedDir = join(NANOTUNE_DIR, "models", "fused");
   mkdirSync(fusedDir, { recursive: true });
   writeFileSync(join(fusedDir, "config.json"), "{}");
+}
+
+// The real base-model cache lives under os.homedir(), not the project
+// directory, so it can't be sandboxed with process.chdir like everything
+// else here. CleanCommand accepts a baseModelCacheDir override for exactly
+// this — production never passes it, tests point it at a throwaway dir.
+const FAKE_BASE_CACHE_DIR = join(TEST_DIR, ".fake-base-cache");
+
+function writeBaseModelCache() {
+  mkdirSync(FAKE_BASE_CACHE_DIR, { recursive: true });
+  writeFileSync(
+    join(FAKE_BASE_CACHE_DIR, "org--model-q4_k_m.gguf"),
+    "x".repeat(1024),
+  );
 }
 
 function writeEvalExamples(lines: object[]) {
@@ -361,6 +375,9 @@ test.serial("CleanCommand without yes waits for confirmation before deleting", a
     t.true(output.includes("Remove it?"));
     t.false(output.includes("Removed fused model cache"));
     t.true(existsSync(fusedDir));
+    // Pinned wording: the single-cache confirm screen must read exactly as
+    // it did before --target existed, not "Fused model cache is kept...".
+    t.true(output.includes("This is kept to speed up repeat exports via --skip-fuse."));
   } finally {
     teardown();
   }
@@ -461,6 +478,122 @@ test.serial("CleanCommand leaves the cache in place on Escape", async (t) => {
     t.true(existsSync(fusedDir));
   } finally {
     process.stdin.isTTY = originalIsTTY;
+    teardown();
+  }
+});
+
+// ── clean: --target ─────────────────────────────────────────────────
+
+test("validateCleanTarget defaults to fused when --target is omitted", (t) => {
+  t.deepEqual(validateCleanTarget(undefined), { target: "fused" });
+});
+
+test("validateCleanTarget accepts fused, base, and all", (t) => {
+  t.deepEqual(validateCleanTarget("fused"), { target: "fused" });
+  t.deepEqual(validateCleanTarget("base"), { target: "base" });
+  t.deepEqual(validateCleanTarget("all"), { target: "all" });
+});
+
+test("validateCleanTarget rejects an unknown target", (t) => {
+  const result = validateCleanTarget("bogus");
+  t.true("error" in result);
+  if ("error" in result) {
+    t.true(result.error.includes("bogus"));
+    t.true(result.error.includes("fused, base, all"));
+  }
+});
+
+test.serial("CleanCommand rejects an invalid --target", async (t) => {
+  try {
+    setupProject();
+    const output = await renderCommand(
+      <CleanCommand options={{ target: "bogus" }} />,
+      "Invalid target",
+    );
+    t.true(output.includes("Invalid target: bogus"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("CleanCommand --target base reports nothing to clean when the base cache is absent", async (t) => {
+  try {
+    setupEmptyDir(); // No project at all — --target base needs none.
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    const output = await renderCommand(
+      <CleanCommand
+        options={{ target: "base" }}
+        baseModelCacheDir={FAKE_BASE_CACHE_DIR}
+      />,
+      "Nothing to clean",
+    );
+    t.true(output.includes("Nothing to clean"));
+    t.false(output.includes("Not a Nanotune project"));
+  } finally {
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    teardown();
+  }
+});
+
+test.serial("CleanCommand --target base removes the base-model cache with --yes", async (t) => {
+  try {
+    setupEmptyDir();
+    writeBaseModelCache();
+    t.true(existsSync(FAKE_BASE_CACHE_DIR));
+    const output = await renderCommand(
+      <CleanCommand
+        options={{ target: "base", yes: true }}
+        baseModelCacheDir={FAKE_BASE_CACHE_DIR}
+      />,
+      "Removed base model cache",
+    );
+    t.true(output.includes("Removed base model cache"));
+    t.true(output.includes("Freed:"));
+    t.false(existsSync(FAKE_BASE_CACHE_DIR));
+  } finally {
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    teardown();
+  }
+});
+
+test.serial("CleanCommand --target all removes both caches when present", async (t) => {
+  try {
+    setupProject();
+    writeFusedModel();
+    writeBaseModelCache();
+    const fusedDir = getFusedModelDir();
+    const output = await renderCommand(
+      <CleanCommand
+        options={{ target: "all", yes: true }}
+        baseModelCacheDir={FAKE_BASE_CACHE_DIR}
+      />,
+      "Removed fused model cache and base model cache",
+    );
+    t.true(output.includes("Removed fused model cache and base model cache"));
+    t.false(existsSync(fusedDir));
+    t.false(existsSync(FAKE_BASE_CACHE_DIR));
+  } finally {
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
+    teardown();
+  }
+});
+
+test.serial("CleanCommand --target all with no project still cleans the base cache", async (t) => {
+  try {
+    setupEmptyDir(); // No project — the fused/ half of --target all is skipped, not an error.
+    writeBaseModelCache();
+    const output = await renderCommand(
+      <CleanCommand
+        options={{ target: "all", yes: true }}
+        baseModelCacheDir={FAKE_BASE_CACHE_DIR}
+      />,
+      "Removed base model cache",
+    );
+    t.false(output.includes("Not a Nanotune project"));
+    t.true(output.includes("Removed base model cache"));
+    t.false(existsSync(FAKE_BASE_CACHE_DIR));
+  } finally {
+    rmSync(FAKE_BASE_CACHE_DIR, { recursive: true, force: true });
     teardown();
   }
 });

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -776,6 +777,103 @@ test.serial(
       writeFileSync(join(SIZE_TEST_DIR, "model.safetensors"), "x");
       t.true(hasUsableFusedModel(SIZE_TEST_DIR));
     } finally {
+      rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
+    }
+  },
+);
+
+function writeShardedModel(dirPath: string, presentShards: number, totalShards: number) {
+  const weightMap: Record<string, string> = {};
+  for (let i = 1; i <= totalShards; i++) {
+    const shardName = `model-${String(i).padStart(5, "0")}-of-${String(totalShards).padStart(5, "0")}.safetensors`;
+    weightMap[`layer.${i}.weight`] = shardName;
+    if (i <= presentShards) {
+      writeFileSync(join(dirPath, shardName), "x");
+    }
+  }
+  writeFileSync(
+    join(dirPath, "model.safetensors.index.json"),
+    JSON.stringify({ weight_map: weightMap }),
+  );
+}
+
+test.serial(
+  "hasUsableFusedModel is false when a sharded fuse is interrupted partway through",
+  (t) => {
+    resetSizeTestDir();
+    try {
+      // Regression: an interrupted fuse that wrote shard 1 of 3 used to read
+      // as usable because *any* .safetensors file passed the old check.
+      writeShardedModel(SIZE_TEST_DIR, 1, 3);
+      t.false(hasUsableFusedModel(SIZE_TEST_DIR));
+    } finally {
+      rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
+    }
+  },
+);
+
+test.serial(
+  "hasUsableFusedModel is true once every shard in the index is present",
+  (t) => {
+    resetSizeTestDir();
+    try {
+      writeShardedModel(SIZE_TEST_DIR, 3, 3);
+      t.true(hasUsableFusedModel(SIZE_TEST_DIR));
+    } finally {
+      rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
+    }
+  },
+);
+
+test.serial(
+  "hasUsableFusedModel is false when model.safetensors.index.json is malformed",
+  (t) => {
+    resetSizeTestDir();
+    try {
+      // The index is written before the shards, same hazard as the plain
+      // .safetensors case: a still-being-written index.json is truncated
+      // JSON, not valid JSON with an empty weight_map.
+      writeFileSync(join(SIZE_TEST_DIR, "model.safetensors.index.json"), "{not json");
+      writeFileSync(join(SIZE_TEST_DIR, "model-00001-of-00003.safetensors"), "x");
+      t.false(hasUsableFusedModel(SIZE_TEST_DIR));
+    } finally {
+      rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
+    }
+  },
+);
+
+test.serial(
+  "getDirectorySize and hasUsableFusedModel survive a permission error on the directory itself",
+  (t) => {
+    resetSizeTestDir();
+    const locked = join(SIZE_TEST_DIR, "locked");
+    mkdirSync(locked);
+    writeFileSync(join(locked, "model.safetensors"), "x".repeat(10));
+    try {
+      chmodSync(locked, 0o000);
+    } catch {
+      // Can't restrict permissions on this platform/user — nothing to
+      // verify here (Windows and root don't enforce chmod for reads).
+      t.pass();
+      rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
+      return;
+    }
+    let permissionEnforced = true;
+    try {
+      readdirSync(locked);
+      permissionEnforced = false;
+    } catch {
+      // Expected — permission bits are enforced on this platform/user.
+    }
+    try {
+      if (!permissionEnforced) {
+        t.pass();
+        return;
+      }
+      t.is(getDirectorySize(locked), 0);
+      t.false(hasUsableFusedModel(locked));
+    } finally {
+      chmodSync(locked, 0o755);
       rmSync(SIZE_TEST_DIR, { recursive: true, force: true });
     }
   },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
 import {
+	type Dirent,
 	existsSync,
 	mkdirSync,
 	readdirSync,
@@ -76,8 +77,16 @@ export function getDirectorySize(dirPath: string): number {
 	if (!existsSync(dirPath)) {
 		return 0;
 	}
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dirPath, {withFileTypes: true});
+	} catch {
+		// Permission error (or similar) reading the directory itself, as
+		// opposed to an entry inside it below — nothing to sum.
+		return 0;
+	}
 	let total = 0;
-	for (const entry of readdirSync(dirPath, {withFileTypes: true})) {
+	for (const entry of entries) {
 		const entryPath = join(dirPath, entry.name);
 		try {
 			if (entry.isDirectory()) {
@@ -98,12 +107,40 @@ export function getDirectorySize(dirPath: string): number {
  * empty or partially-written directory. `mlx_lm.fuse` creates `--save-path`
  * before it finishes writing weights, so directory existence alone isn't a
  * reliable signal that a fuse completed.
+ *
+ * A model sharded across multiple `.safetensors` files ships a
+ * `model.safetensors.index.json` naming every shard in its `weight_map` — so
+ * when that index exists, completeness means every shard it lists is present,
+ * not just any single one (an interrupt after shard 1 of N would otherwise
+ * still read as usable). Single-file models have no index; any `.safetensors`
+ * file is the whole model.
  */
 export function hasUsableFusedModel(dirPath: string): boolean {
 	if (!existsSync(dirPath)) {
 		return false;
 	}
-	return readdirSync(dirPath).some(name => name.endsWith('.safetensors'));
+	const indexPath = join(dirPath, 'model.safetensors.index.json');
+	if (existsSync(indexPath)) {
+		try {
+			const index = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
+				weight_map?: Record<string, string>;
+			};
+			const shardNames = new Set(Object.values(index.weight_map ?? {}));
+			return (
+				shardNames.size > 0 &&
+				[...shardNames].every(name => existsSync(join(dirPath, name)))
+			);
+		} catch {
+			return false; // Malformed or still-being-written index.json.
+		}
+	}
+	let entries: string[];
+	try {
+		entries = readdirSync(dirPath);
+	} catch {
+		return false;
+	}
+	return entries.some(name => name.endsWith('.safetensors'));
 }
 
 /**

--- a/src/lib/model-cache.spec.ts
+++ b/src/lib/model-cache.spec.ts
@@ -8,7 +8,9 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import test from "ava";
 import {
+  getBaseModelCacheDir,
   getBaseModelCachePath,
+  hasBaseModelCache,
   sanitizeModelId,
   sweepStaleCacheArtifacts,
 } from "./model-cache.js";
@@ -37,6 +39,75 @@ test("getBaseModelCachePath varies with quantization", (t) => {
   const q4 = getBaseModelCachePath("org/model", "q4_k_m");
   const f16 = getBaseModelCachePath("org/model", "f16");
   t.not(q4, f16);
+});
+
+test("getBaseModelCacheDir matches getBaseModelCachePath's directory", (t) => {
+  const dir = getBaseModelCacheDir();
+  const path = getBaseModelCachePath("org/model", "q4_k_m");
+  t.is(dir, join(homedir(), ".nanotune", "models", "base-cache"));
+  t.true(path.startsWith(dir));
+});
+
+// ── hasBaseModelCache ────────────────────────────────────────────────
+
+const BASE_CACHE_TEST_DIR = join(process.cwd(), ".test-model-cache-base");
+
+test.serial("hasBaseModelCache is false when the directory doesn't exist", (t) => {
+  rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  t.false(hasBaseModelCache(BASE_CACHE_TEST_DIR));
+});
+
+test.serial("hasBaseModelCache is false for an empty directory", (t) => {
+  rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BASE_CACHE_TEST_DIR, { recursive: true });
+  try {
+    t.false(hasBaseModelCache(BASE_CACHE_TEST_DIR));
+  } finally {
+    rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  }
+});
+
+test.serial("hasBaseModelCache is true once a cached GGUF is present", (t) => {
+  rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BASE_CACHE_TEST_DIR, { recursive: true });
+  try {
+    writeFileSync(join(BASE_CACHE_TEST_DIR, "org--model-q4_k_m.gguf"), "stub");
+    t.true(hasBaseModelCache(BASE_CACHE_TEST_DIR));
+  } finally {
+    rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  }
+});
+
+test.serial("hasBaseModelCache ignores an orphaned .tmp-<pid> leftover", (t) => {
+  // Regression: a crashed benchmark --base run can leave a .tmp-<pid>.gguf
+  // behind before sweepStaleCacheArtifacts gets a chance to remove it. That
+  // debris isn't a usable cache entry and shouldn't be reported as one.
+  rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BASE_CACHE_TEST_DIR, { recursive: true });
+  try {
+    writeFileSync(
+      join(BASE_CACHE_TEST_DIR, "org--model-q4_k_m.tmp-999999.gguf"),
+      "stub",
+    );
+    t.false(hasBaseModelCache(BASE_CACHE_TEST_DIR));
+  } finally {
+    rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  }
+});
+
+test.serial("hasBaseModelCache is true when a real entry sits alongside .tmp debris", (t) => {
+  rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BASE_CACHE_TEST_DIR, { recursive: true });
+  try {
+    writeFileSync(join(BASE_CACHE_TEST_DIR, "org--model-q4_k_m.gguf"), "stub");
+    writeFileSync(
+      join(BASE_CACHE_TEST_DIR, "org--other-q4_k_m.tmp-999999.gguf"),
+      "stub",
+    );
+    t.true(hasBaseModelCache(BASE_CACHE_TEST_DIR));
+  } finally {
+    rmSync(BASE_CACHE_TEST_DIR, { recursive: true, force: true });
+  }
 });
 
 // ── sweepStaleCacheArtifacts ─────────────────────────────────────────

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -50,7 +50,9 @@ export function getBaseModelCachePath(
  * `dir` defaults to the real cache directory but can be overridden, so tests
  * don't have to touch the developer's actual home directory.
  */
-export function hasBaseModelCache(dir: string = getBaseModelCacheDir()): boolean {
+export function hasBaseModelCache(
+	dir: string = getBaseModelCacheDir(),
+): boolean {
 	if (!existsSync(dir)) {
 		return false;
 	}

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -13,23 +13,52 @@ export function sanitizeModelId(modelId: string): string {
 }
 
 /**
+ * The whole base-model cache directory, shared across every project that
+ * fine-tunes from a base model this machine has already downloaded/quantized.
+ * Lives under the home directory (like `~/.nanotune/llama.cpp`) rather than
+ * the project's `.nanotune/models/`, since the expensive download+convert+
+ * quantize work is reusable across projects.
+ */
+export function getBaseModelCacheDir(): string {
+	return join(homedir(), '.nanotune', 'models', 'base-cache');
+}
+
+/**
  * Path to the cached quantized GGUF for a base model, keyed by model id and
- * quantization. Lives under the home directory (like `~/.nanotune/llama.cpp`)
- * rather than the project's `.nanotune/models/`, since the expensive
- * download+convert+quantize work is reusable across every project that
- * fine-tunes from the same base model.
+ * quantization.
  */
 export function getBaseModelCachePath(
 	baseModel: string,
 	quantization: QuantizationType,
 ): string {
 	return join(
-		homedir(),
-		'.nanotune',
-		'models',
-		'base-cache',
+		getBaseModelCacheDir(),
 		`${sanitizeModelId(baseModel)}-${quantization}.gguf`,
 	);
+}
+
+/**
+ * Whether the base-model cache directory has a real, complete cache entry
+ * in it. Each cached GGUF lands at its final filename via `renameSync` from
+ * a `.tmp-<pid>` sibling (see `sweepStaleCacheArtifacts`), so unlike the
+ * fused-model cache, a file's mere presence is normally enough — except a
+ * `.tmp-<pid>` file itself is never a complete entry, whether its writer is
+ * still running or crashed before `sweepStaleCacheArtifacts` could remove
+ * it. Ignoring those (rather than sweeping first) also means a directory
+ * holding only an in-progress download correctly reports nothing to clean.
+ *
+ * `dir` defaults to the real cache directory but can be overridden, so tests
+ * don't have to touch the developer's actual home directory.
+ */
+export function hasBaseModelCache(dir: string = getBaseModelCacheDir()): boolean {
+	if (!existsSync(dir)) {
+		return false;
+	}
+	try {
+		return readdirSync(dir).some(name => !name.includes('.tmp-'));
+	} catch {
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #125: three follow-up correctness gaps in the fused-model cache handling from the `nanotune clean` PR (#70), all deliberately deferred there to keep that PR scoped:

- `hasUsableFusedModel()` used to treat *any* `.safetensors` file as proof a fuse completed, so a multi-shard model interrupted after shard 1 of N still read as "usable." It now reads `model.safetensors.index.json` (when present) and checks every listed shard actually exists.
- `getDirectorySize()` and `hasUsableFusedModel()` now guard their top-level `readdirSync` call: a permission error reading the `fused/` directory itself no longer crashes `nanotune status`.
- `nanotune clean` now accepts `--target <fused|base|all>` (default `fused`, unchanged) to also cover the shared base-model cache at `~/.nanotune/models/base-cache` (used by `nanotune benchmark --base`). `--target base`/`--target all` don't require being inside a project, since that cache isn't project-scoped.
- Caught during implementation: `hasBaseModelCache()` was counting an orphaned `.tmp-<pid>.gguf` (left behind by a crashed `benchmark --base` run) as a real cache entry — fixed to ignore `.tmp-` debris.

Two lower-severity items surfaced during review were deliberately **not** fixed here and instead folded into the existing (not-yet-filed) concurrency-race follow-up, since they share its root cause no locking mechanism exists anywhere in this codebase: a `clean --target base` vs. concurrent `benchmark --base` race (same class as the already-deferred clean/export race), and a stale `model.safetensors.index.json` surviving across two differently-shaped fuses (traced through fails safe in practice, forcing a harmless re-fuse rather than a false positive).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

> Same caveat as the #70 PR: this dev machine is Windows, and `pnpm test:all` has pre-existing, unrelated Windows-only failures (AVA EPERM races, POSIX file-mode assertions). Verified instead with `tsc --noEmit`, `knip`, `biome check` on all touched files, and targeted `ava` runs (`config.spec.ts` + `model-cache.spec.ts` + `commands.spec.tsx`): **132/132 passing**, including new tests for: interrupted sharded fuses, a malformed `index.json`, a permission-error on the cache directory (platform-conditional, since Windows/root don't enforce it), `hasBaseModelCache` with/without orphaned `.tmp-` debris, all three `--target` modes, `validateCleanTarget`, and a pinned-wording test guarding the unchanged default-path messaging.

### Manual Testing

- [ ] Tested `nanotune init`
- [ ] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export`
- [ ] Tested `nanotune benchmark`

*(Not exercised manually: same Apple-Silicon-only / Windows dev-machine constraint as before. This PR doesn't touch `export.tsx`/`benchmark.tsx` logic directly; `getBaseModelCachePath`'s behavior is unchanged and covered by existing `model-cache.spec.ts` tests.)*

## Checklist

- [x] Code follows project style guidelines (`pnpm format`) : verified via `biome check` (no `--write`) on all changed files, clean aside from a known Windows `core.autocrlf` line-ending artifact confirmed harmless via `git diff --cached`.
- [x] Self-review completed: ran `/code-review` twice (once mid-implementation, once on the finished diff); the second pass found the `.tmp-<pid>` bug fixed above, plus the two items deferred to the follow-up issue.
- [x] Documentation updated (if needed): `docs/commands/clean.md` updated for `--target`.
- [x] No breaking changes (or clearly documented): plain `nanotune clean` (no flags) is untouched; pinned with a test asserting its exact confirm-screen wording.