### PR TITLE
feat: add benchmark review to promote failures into training data

### DIFF
--- a/docs/guides/training-tips.md
+++ b/docs/guides/training-tips.md
@@ -50,15 +50,13 @@ The most effective approach is an iterative cycle of training and benchmarking:
 
 1. **Train** your model with the current dataset
 2. **Benchmark** to measure accuracy and identify failures
-3. **Review** the markdown report — focus on failed tests
-4. **Add training examples** that address the specific failures
-5. **Re-train and benchmark** again
+3. **Review** the failures and correct them into training examples
+4. **Re-train and benchmark** again
 
 ```bash
 nanotune train
 nanotune benchmark --preset medium
-# Review .nanotune/benchmarks/benchmark-*.md
-nanotune data add    # Add examples for failures
+nanotune benchmark review    # Walk each failure, type a corrected answer
 nanotune train
 nanotune benchmark --preset medium
 ```

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -269,6 +269,21 @@ benchmarkCommand
 		render(<BenchmarkCompareCommand fileA={fileA} fileB={fileB} />);
 	});
 
+benchmarkCommand
+	.command('review [report]')
+	.description(
+		'Review failed tests from a saved benchmark report and promote corrected answers into train.jsonl',
+	)
+	.action(async (report?: string) => {
+		const {BenchmarkReviewCommand} = await import(
+			'./commands/benchmark/review.js'
+		);
+		renderInteractive(
+			'benchmark review',
+			<BenchmarkReviewCommand report={report} />,
+		);
+	});
+
 // Chat command
 program
 	.command('chat')

--- a/src/commands/benchmark/review.spec.tsx
+++ b/src/commands/benchmark/review.spec.tsx
@@ -1,0 +1,313 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "ava";
+import { render } from "ink-testing-library";
+import { loadTrainingData } from "../../lib/data.js";
+import type { BenchmarkResult } from "../../types/index.js";
+import { BenchmarkReviewCommand } from "./review.js";
+
+const ORIG_CWD = process.cwd();
+const TEST_DIR = join(ORIG_CWD, ".test-review-spec");
+const NANOTUNE_DIR = join(TEST_DIR, ".nanotune");
+const BENCH_DIR = join(NANOTUNE_DIR, "benchmarks");
+const DATA_DIR = join(NANOTUNE_DIR, "data");
+
+const CONFIG = {
+  name: "test-project",
+  version: "1.0.0",
+  baseModel: "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+  contextMessage: { role: "system", content: "You are helpful." },
+  training: {
+    iterations: 150,
+    learningRate: 5e-5,
+    batchSize: 4,
+    numLayers: 16,
+    stepsPerEval: 50,
+    saveEvery: 50,
+  },
+  export: { quantization: "q4_k_m", outputName: "test" },
+};
+
+function setupProject() {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(BENCH_DIR, { recursive: true });
+  mkdirSync(DATA_DIR, { recursive: true });
+  writeFileSync(
+    join(NANOTUNE_DIR, "config.json"),
+    JSON.stringify(CONFIG, null, 2),
+  );
+  process.chdir(TEST_DIR);
+}
+
+function setupEmptyDir() {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.chdir(TEST_DIR);
+}
+
+function teardown() {
+  process.chdir(ORIG_CWD);
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  process.exitCode = 0;
+}
+
+function writeRun(
+  filename: string,
+  overrides: Partial<BenchmarkResult> = {},
+): string {
+  const path = join(BENCH_DIR, filename);
+  const body: BenchmarkResult = {
+    model: "test-model",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    summary: { total: 2, passed: 0, failed: 2, passRate: 0 },
+    categories: {},
+    results: [],
+    failures: [],
+    ...overrides,
+  };
+  writeFileSync(path, JSON.stringify(body, null, 2));
+  return path;
+}
+
+async function waitFor(
+  getOutput: () => string,
+  expected: string,
+  timeout = 2000,
+) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (getOutput().includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 60));
+
+// ── error states ──────────────────────────────────────────────────────
+
+test.serial("refuses to run outside a project", async (t) => {
+  try {
+    setupEmptyDir();
+    process.exitCode = 0;
+    const instance = render(<BenchmarkReviewCommand />);
+    const output = () => instance.frames.join("\n");
+    await waitFor(output, "Not a Nanotune project");
+    instance.unmount();
+    t.true(output().includes("Not a Nanotune project"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("reports when no saved benchmark runs exist", async (t) => {
+  try {
+    setupProject();
+    process.exitCode = 0;
+    const instance = render(<BenchmarkReviewCommand />);
+    const output = () => instance.frames.join("\n");
+    await waitFor(output, "No saved benchmark runs found");
+    instance.unmount();
+    t.true(output().includes("No saved benchmark runs found"));
+  } finally {
+    teardown();
+  }
+});
+
+test.serial("reports an error for an unknown report name", async (t) => {
+  try {
+    setupProject();
+    process.exitCode = 0;
+    const instance = render(
+      <BenchmarkReviewCommand report="does-not-exist" />,
+    );
+    const output = () => instance.frames.join("\n");
+    await waitFor(output, "Could not find a benchmark run");
+    instance.unmount();
+    t.true(output().includes("Could not find a benchmark run"));
+  } finally {
+    teardown();
+  }
+});
+
+// ── zero failures ─────────────────────────────────────────────────────
+
+test.serial(
+  "a report with no failures says so and does not enter the review loop",
+  async (t) => {
+    try {
+      setupProject();
+      writeRun("benchmark-clean.json", {
+        summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
+        failures: [],
+      });
+      const instance = render(<BenchmarkReviewCommand />);
+      const output = () => instance.frames.join("\n");
+      await waitFor(output, "nothing to review");
+      instance.unmount();
+      t.true(output().includes("nothing to review"));
+    } finally {
+      teardown();
+    }
+  },
+);
+
+// ── the review loop ───────────────────────────────────────────────────
+
+test.serial(
+  "typing a correction appends it to train.jsonl and advances to the next failure",
+  async (t) => {
+    const original = process.stdin.isTTY;
+    try {
+      setupProject();
+      writeRun("benchmark-run.json", {
+        failures: [
+          { id: 1, prompt: "list files", expected: ["ls"], actual: "dir" },
+          { id: 2, prompt: "show pwd", expected: ["pwd"], actual: "cd" },
+        ],
+      });
+      process.stdin.isTTY = true;
+
+      const instance = render(<BenchmarkReviewCommand />);
+      const output = () => instance.frames.join("\n");
+      await waitFor(output, "Failure 1/2");
+      await settle();
+      instance.stdin.write("ls");
+      await settle();
+      instance.stdin.write("\r");
+      await waitFor(output, "Failure 2/2");
+      instance.unmount();
+
+      const data = loadTrainingData();
+      t.is(data.length, 1, output());
+      const messages = data[0].messages;
+      t.true(
+        messages.some((m) => m.role === "user" && m.content === "list files"),
+      );
+      t.true(
+        messages.some((m) => m.role === "assistant" && m.content === "ls"),
+      );
+      // The project's context message travels with the example, same as
+      // chat's /keep.
+      t.true(
+        messages.some(
+          (m) => m.role === "system" && m.content === "You are helpful.",
+        ),
+      );
+    } finally {
+      process.stdin.isTTY = original;
+      teardown();
+    }
+  },
+);
+
+test.serial(
+  "an empty submission skips without writing, and the final tally reports it",
+  async (t) => {
+    const original = process.stdin.isTTY;
+    try {
+      setupProject();
+      writeRun("benchmark-run.json", {
+        failures: [
+          { id: 1, prompt: "list files", expected: ["ls"], actual: "dir" },
+        ],
+      });
+      process.stdin.isTTY = true;
+
+      const instance = render(<BenchmarkReviewCommand />);
+      const output = () => instance.frames.join("\n");
+      await waitFor(output, "Failure 1/1");
+      await settle();
+      instance.stdin.write("\r");
+      await waitFor(output, "skipped");
+      instance.unmount();
+
+      t.is(loadTrainingData().length, 0);
+      t.true(output().includes("1 skipped"), output());
+    } finally {
+      process.stdin.isTTY = original;
+      teardown();
+    }
+  },
+);
+
+test.serial(
+  "a multi-turn failure's correction preserves the earlier turns",
+  async (t) => {
+    const original = process.stdin.isTTY;
+    try {
+      setupProject();
+      writeRun("benchmark-run.json", {
+        failures: [
+          {
+            id: 3,
+            prompt: "follow-up question",
+            messages: [
+              { role: "user", content: "turn one" },
+              { role: "assistant", content: "reply one" },
+              { role: "user", content: "follow-up question" },
+            ],
+            expected: ["expected answer"],
+            actual: "wrong answer",
+          },
+        ],
+      });
+      process.stdin.isTTY = true;
+
+      const instance = render(<BenchmarkReviewCommand />);
+      const output = () => instance.frames.join("\n");
+      await waitFor(output, "Conversation:");
+      await settle();
+      instance.stdin.write("expected answer");
+      await settle();
+      instance.stdin.write("\r");
+      await waitFor(output, "Reviewed 1/1");
+      instance.unmount();
+
+      const data = loadTrainingData();
+      t.is(data.length, 1, output());
+      t.deepEqual(
+        data[0].messages.map((m) => `${m.role}:${m.content}`),
+        [
+          "system:You are helpful.",
+          "user:turn one",
+          "assistant:reply one",
+          "user:follow-up question",
+          "assistant:expected answer",
+        ],
+      );
+    } finally {
+      process.stdin.isTTY = original;
+      teardown();
+    }
+  },
+);
+
+test.serial(
+  "Esc stops the review early and reports partial progress",
+  async (t) => {
+    const original = process.stdin.isTTY;
+    try {
+      setupProject();
+      writeRun("benchmark-run.json", {
+        failures: [
+          { id: 1, prompt: "a", expected: ["x"], actual: "y" },
+          { id: 2, prompt: "b", expected: ["x"], actual: "y" },
+        ],
+      });
+      process.stdin.isTTY = true;
+
+      const instance = render(<BenchmarkReviewCommand />);
+      const output = () => instance.frames.join("\n");
+      await waitFor(output, "Failure 1/2");
+      await settle();
+      instance.stdin.write("");
+      await waitFor(output, "Reviewed 0/2");
+      instance.unmount();
+
+      t.true(output().includes("Reviewed 0/2"));
+    } finally {
+      process.stdin.isTTY = original;
+      teardown();
+    }
+  },
+);

--- a/src/commands/benchmark/review.tsx
+++ b/src/commands/benchmark/review.tsx
@@ -1,0 +1,261 @@
+import {StatusMessage, TextInput} from '@inkjs/ui';
+import {Box, Text, useApp} from 'ink';
+import {useEffect, useState} from 'react';
+import {
+	ExitHint,
+	Header,
+	useAutoExit,
+	useKeyInput,
+} from '../../components/index.js';
+import {
+	configExists,
+	findLatestBenchmark,
+	loadBenchmark,
+	loadConfig,
+	resolveBenchmarkPath,
+	resolveContextMessage,
+} from '../../lib/config.js';
+import {
+	appendToTrainingData,
+	appendTrainingExample,
+	countExamples,
+} from '../../lib/data.js';
+import type {BenchmarkResult, ChatMessage} from '../../types/index.js';
+
+interface Props {
+	report?: string;
+}
+
+type Status = 'loading' | 'reviewing' | 'done' | 'error';
+type Failure = BenchmarkResult['failures'][number];
+
+export function BenchmarkReviewCommand({report}: Props) {
+	const {exit} = useApp();
+	const [status, setStatus] = useState<Status>('loading');
+	const [error, setError] = useState<string | null>(null);
+	const [reportName, setReportName] = useState('');
+	const [contextMessage, setContextMessage] = useState<ChatMessage | null>(
+		null,
+	);
+	const [failures, setFailures] = useState<Failure[]>([]);
+	const [index, setIndex] = useState(0);
+	const [savedCount, setSavedCount] = useState(0);
+	const [skippedCount, setSkippedCount] = useState(0);
+	const [lastMessage, setLastMessage] = useState<string | null>(null);
+
+	useAutoExit(status === 'done' || status === 'error', status === 'error');
+
+	useEffect(() => {
+		if (!configExists()) {
+			setError('Not a Nanotune project. Run `nanotune init` first.');
+			setStatus('error');
+			return;
+		}
+
+		try {
+			const path = report
+				? resolveBenchmarkPath(report)
+				: findLatestBenchmark();
+			if (!path) {
+				setError(
+					'No saved benchmark runs found. Run `nanotune benchmark` first.',
+				);
+				setStatus('error');
+				return;
+			}
+
+			const result = loadBenchmark(path);
+
+			try {
+				const config = loadConfig();
+				setContextMessage(resolveContextMessage(config));
+			} catch {
+				// Minimal config (e.g., external benchmark runner) — examples are
+				// saved without a context message, same as benchmark.tsx's run path.
+			}
+
+			setReportName(path.split(/[/\\]/).pop() ?? path);
+			setFailures(result.failures);
+			setStatus(result.failures.length === 0 ? 'done' : 'reviewing');
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : 'Could not load benchmark report',
+			);
+			setStatus('error');
+		}
+	}, [report]);
+
+	useKeyInput((_input, key) => {
+		if (status === 'reviewing') {
+			if (key.escape) {
+				setStatus('done');
+			}
+			return;
+		}
+		if (key.escape || key.return) {
+			exit();
+		}
+	});
+
+	const advance = () => {
+		const next = index + 1;
+		// Set both in the same event-handler pass (rather than nesting setStatus
+		// inside setIndex's updater) so the two updates land in one render — an
+		// out-of-range index must never be visible while status still says
+		// 'reviewing'.
+		if (next >= failures.length) {
+			setStatus('done');
+		}
+		setIndex(next);
+	};
+
+	const handleSubmit = (value: string) => {
+		const current = failures[index];
+		const corrected = value.trim();
+
+		if (!corrected) {
+			setSkippedCount(c => c + 1);
+			setLastMessage(null);
+			advance();
+			return;
+		}
+
+		try {
+			if (current.messages && current.messages.length > 0) {
+				const messages: ChatMessage[] = [
+					...(contextMessage?.content ? [contextMessage] : []),
+					...current.messages,
+					{role: 'assistant', content: corrected},
+				];
+				appendTrainingExample({messages}, false);
+			} else {
+				appendToTrainingData(
+					{
+						contextMessage,
+						userInput: current.prompt,
+						assistantOutput: corrected,
+					},
+					false,
+				);
+			}
+			setSavedCount(c => c + 1);
+			setLastMessage(`Saved (${countExamples()} examples total).`);
+		} catch (err) {
+			setLastMessage(
+				`Could not save: ${err instanceof Error ? err.message : 'write failed'}`,
+			);
+		}
+		advance();
+	};
+
+	if (status === 'error') {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Benchmark Review" />
+				<StatusMessage variant="error">{error}</StatusMessage>
+				<Text> </Text>
+				<ExitHint>Press any key to exit</ExitHint>
+			</Box>
+		);
+	}
+
+	if (status === 'loading') {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Benchmark Review" />
+			</Box>
+		);
+	}
+
+	if (status === 'done') {
+		return (
+			<Box flexDirection="column" padding={1}>
+				<Header title="Benchmark Review" subtitle={reportName} />
+				{failures.length === 0 ? (
+					<StatusMessage variant="success">
+						No failed tests in this report — nothing to review.
+					</StatusMessage>
+				) : (
+					<Text>
+						Reviewed {savedCount + skippedCount}/{failures.length} failures —{' '}
+						<Text color="green" bold>
+							{savedCount} saved
+						</Text>
+						, <Text dimColor>{skippedCount} skipped</Text>.
+					</Text>
+				)}
+				<Text> </Text>
+				<ExitHint>Press any key to exit</ExitHint>
+			</Box>
+		);
+	}
+
+	// reviewing
+	const current = failures[index];
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Header
+				title="Benchmark Review"
+				subtitle={`${reportName} • Failure ${index + 1}/${failures.length} (test #${current.id})`}
+			/>
+
+			{current.messages && current.messages.length > 0 ? (
+				<Box flexDirection="column" marginBottom={1}>
+					<Text bold>Conversation:</Text>
+					{current.messages.map((msg, i) => (
+						<Box key={`msg-${i}`}>
+							<Text dimColor>{msg.role}: </Text>
+							<Text>{msg.content}</Text>
+						</Box>
+					))}
+				</Box>
+			) : (
+				<Box marginBottom={1}>
+					<Text bold>Prompt: </Text>
+					<Text>{current.prompt}</Text>
+				</Box>
+			)}
+
+			{current.expected.length > 0 && (
+				<Box flexDirection="column" marginBottom={1}>
+					<Text bold>Expected (any of):</Text>
+					{current.expected.map((exp, i) => (
+						<Text key={`expected-${i}`} dimColor>
+							- {exp}
+						</Text>
+					))}
+				</Box>
+			)}
+
+			<Box flexDirection="column" marginBottom={1}>
+				<Text bold color="red">
+					Actual:
+				</Text>
+				<Text>{current.actual}</Text>
+			</Box>
+
+			{lastMessage && (
+				<Box marginBottom={1}>
+					<Text dimColor>{lastMessage}</Text>
+				</Box>
+			)}
+
+			<Box>
+				<Text color="yellow" bold>
+					Corrected response:{' '}
+				</Text>
+				<TextInput
+					key={index}
+					onSubmit={handleSubmit}
+					placeholder="Type the correct answer, or press Enter to skip"
+				/>
+			</Box>
+			<Box marginTop={1}>
+				<Text dimColor>
+					[Enter] Save & next (blank = skip) [Esc] Stop reviewing
+				</Text>
+			</Box>
+		</Box>
+	);
+}


### PR DESCRIPTION
Closes #178

## Description

Adds `nanotune benchmark review [report]`: loads a saved benchmark report (the most recent one by default, or an explicit name via the existing `resolveBenchmarkPath`), and walks each failed test, prompt or full conversation, acceptable answers, and the model's actual output, letting you type a corrected response that's appended to `train.jsonl`. Leaving the input blank skips a failure; Esc stops the review early and reports how many were saved vs. skipped. A report with zero failures says so and exits without entering the loop. The benchmark run path (`benchmark.tsx`) is untouched, this only adds a new command over an existing saved report.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] New tests added for new functionality (if applicable)

### Manual Testing

- [ ] Tested `nanotune init`
- [x] Tested `nanotune data` commands (add/import/list/validate)
- [ ] Tested `nanotune train`
- [ ] Tested `nanotune export` 
- [x] Tested `nanotune benchmark`

## Checklist

- [x] Code follows project style guidelines (`pnpm format`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)